### PR TITLE
Normalize demo titles and add Lottery Hash demo (Power of Two Choices)

### DIFF
--- a/public/lottery-hash-dp-preview.svg
+++ b/public/lottery-hash-dp-preview.svg
@@ -1,0 +1,36 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FAFC"/>
+      <stop offset="1" stop-color="#E2E8F0"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#bg)"/>
+  <text x="36" y="56" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">Lottery Hash Demo</text>
+  <text x="36" y="88" fill="#334155" font-family="Arial, sans-serif" font-size="18">Power of Two Choices vs classic hashing</text>
+
+  <rect x="36" y="114" width="260" height="200" rx="14" fill="#FFE4E6"/>
+  <rect x="344" y="114" width="260" height="200" rx="14" fill="#DCFCE7"/>
+  <text x="52" y="140" fill="#9F1239" font-family="Arial, sans-serif" font-size="16" font-weight="700">Classic</text>
+  <text x="360" y="140" fill="#065F46" font-family="Arial, sans-serif" font-size="16" font-weight="700">Lottery (2 choices)</text>
+
+  <rect x="56" y="270" width="14" height="30" rx="3" fill="#FB7185"/>
+  <rect x="76" y="250" width="14" height="50" rx="3" fill="#FB7185"/>
+  <rect x="96" y="232" width="14" height="68" rx="3" fill="#FB7185"/>
+  <rect x="116" y="210" width="14" height="90" rx="3" fill="#FB7185"/>
+  <rect x="136" y="220" width="14" height="80" rx="3" fill="#FB7185"/>
+  <rect x="156" y="194" width="14" height="106" rx="3" fill="#FB7185"/>
+  <rect x="176" y="240" width="14" height="60" rx="3" fill="#FB7185"/>
+  <rect x="196" y="222" width="14" height="78" rx="3" fill="#FB7185"/>
+
+  <rect x="364" y="270" width="14" height="30" rx="3" fill="#34D399"/>
+  <rect x="384" y="262" width="14" height="38" rx="3" fill="#34D399"/>
+  <rect x="404" y="252" width="14" height="48" rx="3" fill="#34D399"/>
+  <rect x="424" y="246" width="14" height="54" rx="3" fill="#34D399"/>
+  <rect x="444" y="244" width="14" height="56" rx="3" fill="#34D399"/>
+  <rect x="464" y="238" width="14" height="62" rx="3" fill="#34D399"/>
+  <rect x="484" y="248" width="14" height="52" rx="3" fill="#34D399"/>
+  <rect x="504" y="242" width="14" height="58" rx="3" fill="#34D399"/>
+
+  <text x="36" y="338" fill="#475569" font-family="Arial, sans-serif" font-size="14">Smaller tallest bar = fewer collision hotspots</text>
+</svg>

--- a/public/lottery-hash-dp-preview.svg
+++ b/public/lottery-hash-dp-preview.svg
@@ -6,31 +6,33 @@
     </linearGradient>
   </defs>
   <rect width="640" height="360" rx="24" fill="url(#bg)"/>
-  <text x="36" y="56" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">Lottery Hash Demo</text>
-  <text x="36" y="88" fill="#334155" font-family="Arial, sans-serif" font-size="18">Power of Two Choices vs classic hashing</text>
+  <text x="30" y="52" fill="#0F172A" font-family="Arial, sans-serif" font-size="30" font-weight="700">Power of Two Choicss Demo</text>
+  <text x="30" y="82" fill="#334155" font-family="Arial, sans-serif" font-size="16">Lucky bucket draw beats standard and human random</text>
 
-  <rect x="36" y="114" width="260" height="200" rx="14" fill="#FFE4E6"/>
-  <rect x="344" y="114" width="260" height="200" rx="14" fill="#DCFCE7"/>
-  <text x="52" y="140" fill="#9F1239" font-family="Arial, sans-serif" font-size="16" font-weight="700">Classic</text>
-  <text x="360" y="140" fill="#065F46" font-family="Arial, sans-serif" font-size="16" font-weight="700">Lottery (2 choices)</text>
+  <rect x="26" y="108" width="188" height="208" rx="14" fill="#FFE4E6"/>
+  <rect x="226" y="108" width="188" height="208" rx="14" fill="#FEF3C7"/>
+  <rect x="426" y="108" width="188" height="208" rx="14" fill="#DCFCE7"/>
+  <text x="40" y="134" fill="#9F1239" font-family="Arial, sans-serif" font-size="14" font-weight="700">Standard</text>
+  <text x="240" y="134" fill="#92400E" font-family="Arial, sans-serif" font-size="14" font-weight="700">Human Random</text>
+  <text x="440" y="134" fill="#065F46" font-family="Arial, sans-serif" font-size="14" font-weight="700">Lucky Bucket</text>
 
-  <rect x="56" y="270" width="14" height="30" rx="3" fill="#FB7185"/>
-  <rect x="76" y="250" width="14" height="50" rx="3" fill="#FB7185"/>
-  <rect x="96" y="232" width="14" height="68" rx="3" fill="#FB7185"/>
-  <rect x="116" y="210" width="14" height="90" rx="3" fill="#FB7185"/>
-  <rect x="136" y="220" width="14" height="80" rx="3" fill="#FB7185"/>
-  <rect x="156" y="194" width="14" height="106" rx="3" fill="#FB7185"/>
-  <rect x="176" y="240" width="14" height="60" rx="3" fill="#FB7185"/>
-  <rect x="196" y="222" width="14" height="78" rx="3" fill="#FB7185"/>
+  <rect x="42" y="274" width="12" height="28" rx="3" fill="#FB7185"/>
+  <rect x="58" y="252" width="12" height="50" rx="3" fill="#FB7185"/>
+  <rect x="74" y="236" width="12" height="66" rx="3" fill="#FB7185"/>
+  <rect x="90" y="220" width="12" height="82" rx="3" fill="#FB7185"/>
+  <rect x="106" y="204" width="12" height="98" rx="3" fill="#FB7185"/>
 
-  <rect x="364" y="270" width="14" height="30" rx="3" fill="#34D399"/>
-  <rect x="384" y="262" width="14" height="38" rx="3" fill="#34D399"/>
-  <rect x="404" y="252" width="14" height="48" rx="3" fill="#34D399"/>
-  <rect x="424" y="246" width="14" height="54" rx="3" fill="#34D399"/>
-  <rect x="444" y="244" width="14" height="56" rx="3" fill="#34D399"/>
-  <rect x="464" y="238" width="14" height="62" rx="3" fill="#34D399"/>
-  <rect x="484" y="248" width="14" height="52" rx="3" fill="#34D399"/>
-  <rect x="504" y="242" width="14" height="58" rx="3" fill="#34D399"/>
+  <rect x="242" y="274" width="12" height="28" rx="3" fill="#F59E0B"/>
+  <rect x="258" y="258" width="12" height="44" rx="3" fill="#F59E0B"/>
+  <rect x="274" y="248" width="12" height="54" rx="3" fill="#F59E0B"/>
+  <rect x="290" y="230" width="12" height="72" rx="3" fill="#F59E0B"/>
+  <rect x="306" y="220" width="12" height="82" rx="3" fill="#F59E0B"/>
 
-  <text x="36" y="338" fill="#475569" font-family="Arial, sans-serif" font-size="14">Smaller tallest bar = fewer collision hotspots</text>
+  <rect x="442" y="274" width="12" height="28" rx="3" fill="#34D399"/>
+  <rect x="458" y="266" width="12" height="36" rx="3" fill="#34D399"/>
+  <rect x="474" y="258" width="12" height="44" rx="3" fill="#34D399"/>
+  <rect x="490" y="252" width="12" height="50" rx="3" fill="#34D399"/>
+  <rect x="506" y="246" width="12" height="56" rx="3" fill="#34D399"/>
+
+  <text x="30" y="340" fill="#475569" font-family="Arial, sans-serif" font-size="13">Shorter tallest bars = fewer hotspot collisions</text>
 </svg>

--- a/src/app/fibonacci-heap-dp/page.js
+++ b/src/app/fibonacci-heap-dp/page.js
@@ -353,7 +353,7 @@ export default function FibonacciHeapDPPage() {
         </button>
       </div>
 
-      <h1 className="text-3xl md:text-4xl font-bold text-center">Fibonacci Heap DP Demo</h1>
+      <h1 className="text-3xl md:text-4xl font-bold text-center">Fibonacci Heap Demo</h1>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-2xl font-semibold mb-3">Traditional description</h2>

--- a/src/app/floyd-cycle-dp/page.js
+++ b/src/app/floyd-cycle-dp/page.js
@@ -211,7 +211,7 @@ export default function FloydCycleDPPage() {
         </button>
       </div>
 
-      <h1 className="text-3xl md:text-4xl font-bold text-center">Floyd Cycle Detection DP Demo</h1>
+      <h1 className="text-3xl md:text-4xl font-bold text-center">Floyd Cycle Detection Demo</h1>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-2xl font-semibold mb-3">Traditional description</h2>

--- a/src/app/lottery-hash-dp/page.js
+++ b/src/app/lottery-hash-dp/page.js
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 const DEFAULT_BUCKETS = 64;
 const DEFAULT_KEYS = 1200;
 const DEFAULT_SEED = 42;
+const DEFAULT_GAME_ROUNDS = 20;
 
 function createGenerator(seed) {
   let state = seed >>> 0;
@@ -28,27 +29,65 @@ function loadStats(loads) {
   };
 }
 
+function pickHumanRandom(random, bucketCount, previousPick, keyIndex) {
+  let pick = Math.floor(random() * bucketCount);
+
+  if (pick === previousPick) {
+    pick = (pick + Math.floor(bucketCount / 3)) % bucketCount;
+  }
+
+  if (keyIndex % 4 === 0) {
+    pick = Math.floor((pick + Math.floor(bucketCount * 0.11)) % bucketCount);
+  }
+
+  if (pick % 2 === 1 && random() > 0.5) {
+    pick -= 1;
+  }
+
+  return Math.max(0, Math.min(bucketCount - 1, pick));
+}
+
 function runHashSim(bucketCount, keyCount, seed) {
   const random = createGenerator(seed);
   const classicLoads = Array(bucketCount).fill(0);
+  const humanLoads = Array(bucketCount).fill(0);
   const choiceLoads = Array(bucketCount).fill(0);
+  let previousHumanPick = -1;
 
   for (let key = 0; key < keyCount; key += 1) {
     const classicBucket = Math.floor(random() * bucketCount);
     classicLoads[classicBucket] += 1;
 
-    const first = Math.floor(random() * bucketCount);
-    const second = Math.floor(random() * bucketCount);
-    const pick = choiceLoads[first] <= choiceLoads[second] ? first : second;
-    choiceLoads[pick] += 1;
+    const humanBucket = pickHumanRandom(random, bucketCount, previousHumanPick, key);
+    humanLoads[humanBucket] += 1;
+    previousHumanPick = humanBucket;
+
+    const luckyA = Math.floor(random() * bucketCount);
+    const luckyB = Math.floor(random() * bucketCount);
+    const luckyPick = choiceLoads[luckyA] <= choiceLoads[luckyB] ? luckyA : luckyB;
+    choiceLoads[luckyPick] += 1;
   }
 
   return {
     classicLoads,
+    humanLoads,
     choiceLoads,
     classicStats: loadStats(classicLoads),
+    humanStats: loadStats(humanLoads),
     choiceStats: loadStats(choiceLoads),
   };
+}
+
+function simulateRoundChoices(bucketCount, roundCount, seed) {
+  const random = createGenerator(seed);
+  const rounds = [];
+  for (let round = 0; round < roundCount; round += 1) {
+    rounds.push([
+      Math.floor(random() * bucketCount),
+      Math.floor(random() * bucketCount),
+    ]);
+  }
+  return rounds;
 }
 
 function BucketBars({ title, loads, colorClass }) {
@@ -63,7 +102,7 @@ function BucketBars({ title, loads, colorClass }) {
             key={`${title}-${index}`}
             className={`flex-1 ${colorClass} rounded-t-sm`}
             style={{ height: `${(load / peak) * 100}%` }}
-            title={`Bucket ${index}: ${load}`}
+            title={`Lucky bucket ${index}: ${load}`}
           />
         ))}
       </div>
@@ -76,17 +115,58 @@ export default function LotteryHashDPPage() {
   const [bucketCount, setBucketCount] = useState(DEFAULT_BUCKETS);
   const [keyCount, setKeyCount] = useState(DEFAULT_KEYS);
   const [seed, setSeed] = useState(DEFAULT_SEED);
+  const [gameRound, setGameRound] = useState(0);
+  const [userLoads, setUserLoads] = useState(() => Array(DEFAULT_BUCKETS).fill(0));
+  const [score, setScore] = useState(0);
 
-  const { classicLoads, choiceLoads, classicStats, choiceStats } = useMemo(
+  const { classicLoads, humanLoads, choiceLoads, classicStats, humanStats, choiceStats } = useMemo(
     () => runHashSim(bucketCount, keyCount, seed),
     [bucketCount, keyCount, seed]
   );
+
+  const gameChoices = useMemo(
+    () => simulateRoundChoices(bucketCount, DEFAULT_GAME_ROUNDS, seed + 777),
+    [bucketCount, seed]
+  );
+
+  const currentChoices = gameChoices[Math.min(gameRound, DEFAULT_GAME_ROUNDS - 1)] ?? [0, 1];
+
+  const resetGame = () => {
+    setGameRound(0);
+    setUserLoads(Array(bucketCount).fill(0));
+    setScore(0);
+  };
 
   const resetAll = () => {
     setBucketCount(DEFAULT_BUCKETS);
     setKeyCount(DEFAULT_KEYS);
     setSeed(DEFAULT_SEED);
+    setGameRound(0);
+    setUserLoads(Array(DEFAULT_BUCKETS).fill(0));
+    setScore(0);
   };
+
+  const chooseLuckyBucket = (bucketIndex) => {
+    if (gameRound >= DEFAULT_GAME_ROUNDS) {
+      return;
+    }
+
+    const [luckyA, luckyB] = currentChoices;
+
+    setUserLoads((previousLoads) => {
+      const nextLoads = [...previousLoads];
+      const betterPick = previousLoads[luckyA] <= previousLoads[luckyB] ? luckyA : luckyB;
+      if (bucketIndex === betterPick) {
+        setScore((previousScore) => previousScore + 1);
+      }
+      nextLoads[bucketIndex] += 1;
+      return nextLoads;
+    });
+
+    setGameRound((previousRound) => previousRound + 1);
+  };
+
+  const userStats = loadStats(userLoads);
 
   return (
     <main className="min-h-screen p-6 md:p-8 flex flex-col items-center gap-5">
@@ -100,44 +180,80 @@ export default function LotteryHashDPPage() {
         </button>
       </div>
 
-      <h1 className="text-3xl md:text-4xl font-bold text-center">Lottery Hash Demo</h1>
+      <h1 className="text-3xl md:text-4xl font-bold text-center">Power of Two Choicss Demo</h1>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-3">What is this called?</h2>
+        <h2 className="text-2xl font-semibold mb-3">Traditional description</h2>
         <p className="text-slate-700 mb-3">
-          The breakthrough idea is commonly called the <strong>Power of Two Choices</strong>. Instead of
-          placing each key into one random bucket, we sample two random buckets and choose the less-loaded
-          one.
+          Think of each hash slot as a <strong>lucky bucket</strong>. Standard hashing tosses each key into one
+          random bucket. Power-of-two hashing gives each key two random lucky buckets and picks the one with
+          less traffic.
         </p>
         <p className="text-slate-700">
-          This demo names it <strong>Lottery Hashing</strong>: every key draws two lottery tickets (two random
-          buckets), then keeps the better one. A tiny extra choice can dramatically reduce collisions and
-          worst-case bucket spikes.
+          That tiny decision makes heavy collision spikes far less likely. We keep the playful name
+          <strong> Lucky Bucket Draw</strong> in this DP while using the formal computer science term too.
         </p>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-blue-200 bg-[#eef6ff] p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-3">How to use</h2>
+        <h2 className="text-2xl font-semibold mb-3">How to play</h2>
         <ul className="list-disc pl-5 space-y-2 text-slate-700">
-          <li>Set how many buckets exist in the hash table.</li>
-          <li>Set how many keys to insert.</li>
-          <li>Change seed to rerun with a different random stream.</li>
-          <li>Compare classic random hashing to Lottery Hashing side-by-side.</li>
+          <li>Set how many lucky buckets exist in the hash table.</li>
+          <li>Set how many keys to insert for the large simulation.</li>
+          <li>Change seed to rerun with a different pseudo-random stream.</li>
+          <li>Compare Standard Random, Human Random, and Lucky Bucket Draw (power of two choices).</li>
+          <li>In the mini-game, pick between two lucky buckets and try to beat your own balancing score.</li>
         </ul>
+      </section>
+
+      <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">Technical explanation</h2>
+        <p className="text-slate-700 mb-3">
+          In classic balls-into-bins hashing, the heaviest bucket grows with about
+          <strong> log n / log log n</strong>. With the power of two choices, the maximum load collapses to about
+          <strong> log log n</strong> (plus a small constant), which is an exponential improvement in tail behavior.
+          In practice this means fewer pathological hot buckets, lower lock contention, and tighter latency
+          distributions under high throughput.
+        </p>
+        <p className="text-slate-700 mb-3">
+          The intuition: each key gets two independent opportunities. Picking the less-loaded option applies
+          negative feedback to hotspots, so overloaded buckets become less likely to receive additional keys.
+          Over many inserts this creates a self-balancing effect that plain one-choice random placement cannot
+          reproduce.
+        </p>
+        <p className="text-slate-700">
+          APA source: Mitzenmacher, M. (2001). The power of two choices in randomized load balancing.
+          <em> IEEE Transactions on Parallel and Distributed Systems, 12</em>(10), 1094-1104.
+          {' '}
+          <a
+            href="https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf"
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-700 underline"
+          >
+            https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf
+          </a>
+        </p>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-2xl font-semibold mb-4">Controls</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <label className="flex flex-col gap-2">
-            <span className="font-semibold">Buckets: {bucketCount}</span>
+            <span className="font-semibold">Lucky Buckets: {bucketCount}</span>
             <input
               type="range"
               min="16"
               max="160"
               step="8"
               value={bucketCount}
-              onChange={(event) => setBucketCount(Number.parseInt(event.target.value, 10))}
+              onChange={(event) => {
+                const next = Number.parseInt(event.target.value, 10);
+                setBucketCount(next);
+                setUserLoads(Array(next).fill(0));
+                setGameRound(0);
+                setScore(0);
+              }}
             />
           </label>
 
@@ -161,7 +277,12 @@ export default function LotteryHashDPPage() {
               max="300"
               step="1"
               value={seed}
-              onChange={(event) => setSeed(Number.parseInt(event.target.value, 10))}
+              onChange={(event) => {
+                setSeed(Number.parseInt(event.target.value, 10));
+                setUserLoads(Array(bucketCount).fill(0));
+                setGameRound(0);
+                setScore(0);
+              }}
             />
           </label>
         </div>
@@ -174,31 +295,81 @@ export default function LotteryHashDPPage() {
           >
             Reset All
           </button>
+          <button
+            type="button"
+            onClick={resetGame}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500"
+          >
+            Reset Mini-Game
+          </button>
         </div>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-2xl font-semibold mb-4">Game / Visualization</h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-          <BucketBars title="Classic Random Hashing" loads={classicLoads} colorClass="bg-rose-400" />
-          <BucketBars title="Lottery Hashing (2 Choices)" loads={choiceLoads} colorClass="bg-emerald-400" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+          <BucketBars title="Standard Random Hash" loads={classicLoads} colorClass="bg-rose-400" />
+          <BucketBars title="Human Random Hash" loads={humanLoads} colorClass="bg-amber-400" />
+          <BucketBars title="Lucky Bucket Draw (Power of Two)" loads={choiceLoads} colorClass="bg-emerald-400" />
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-slate-700">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-slate-700 mb-4">
           <div className="rounded-lg bg-rose-50 border border-rose-100 p-3">
-            <h3 className="font-semibold">Classic stats</h3>
-            <p>Max bucket load: {classicStats.max}</p>
-            <p>Average load: {classicStats.avg.toFixed(2)}</p>
-            <p>Used buckets: {classicStats.used}/{bucketCount}</p>
-            <p>Min load: {classicStats.min}</p>
+            <h3 className="font-semibold">Standard stats</h3>
+            <p>Max load: {classicStats.max}</p>
+            <p>Average: {classicStats.avg.toFixed(2)}</p>
+          </div>
+          <div className="rounded-lg bg-amber-50 border border-amber-100 p-3">
+            <h3 className="font-semibold">Human random stats</h3>
+            <p>Max load: {humanStats.max}</p>
+            <p>Average: {humanStats.avg.toFixed(2)}</p>
           </div>
           <div className="rounded-lg bg-emerald-50 border border-emerald-100 p-3">
-            <h3 className="font-semibold">Lottery stats</h3>
-            <p>Max bucket load: {choiceStats.max}</p>
-            <p>Average load: {choiceStats.avg.toFixed(2)}</p>
-            <p>Used buckets: {choiceStats.used}/{bucketCount}</p>
-            <p>Min load: {choiceStats.min}</p>
+            <h3 className="font-semibold">Power of two stats</h3>
+            <p>Max load: {choiceStats.max}</p>
+            <p>Average: {choiceStats.avg.toFixed(2)}</p>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <h3 className="font-semibold mb-2">Mini-game: pick the better lucky bucket</h3>
+          <p className="text-slate-700 mb-3">
+            Round {Math.min(gameRound + 1, DEFAULT_GAME_ROUNDS)} / {DEFAULT_GAME_ROUNDS} · Score: {score}
+          </p>
+          {gameRound >= DEFAULT_GAME_ROUNDS ? (
+            <p className="text-slate-700">Game complete. Reset Mini-Game to play again with the same settings.</p>
+          ) : (
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-500"
+                onClick={() => chooseLuckyBucket(currentChoices[0])}
+              >
+                Choose lucky bucket #{currentChoices[0]}
+              </button>
+              <button
+                type="button"
+                className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-500"
+                onClick={() => chooseLuckyBucket(currentChoices[1])}
+              >
+                Choose lucky bucket #{currentChoices[1]}
+              </button>
+            </div>
+          )}
+          <p className="text-sm text-slate-600 mt-3">
+            Tip: You gain a point when you pick the less-loaded bucket between the two offered choices.
+          </p>
+          <div className="mt-3 rounded bg-white border border-slate-200 p-3">
+            <p className="font-semibold mb-2">Your mini-game bucket balance</p>
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-8 gap-2 text-xs">
+              {userLoads.slice(0, Math.min(bucketCount, 32)).map((value, index) => (
+                <div key={`user-load-${index}`} className="rounded bg-slate-100 p-2 text-center">
+                  #{index}: {value}
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-slate-700 mt-2">Your max load so far: {userStats.max}</p>
           </div>
         </div>
       </section>

--- a/src/app/lottery-hash-dp/page.js
+++ b/src/app/lottery-hash-dp/page.js
@@ -1,0 +1,207 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const DEFAULT_BUCKETS = 64;
+const DEFAULT_KEYS = 1200;
+const DEFAULT_SEED = 42;
+
+function createGenerator(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 2 ** 32;
+  };
+}
+
+function loadStats(loads) {
+  const total = loads.reduce((sum, value) => sum + value, 0);
+  const max = loads.reduce((current, value) => Math.max(current, value), 0);
+  const min = loads.reduce((current, value) => Math.min(current, value), Number.POSITIVE_INFINITY);
+  const used = loads.filter((value) => value > 0).length;
+
+  return {
+    max,
+    min: Number.isFinite(min) ? min : 0,
+    avg: total / loads.length,
+    used,
+  };
+}
+
+function runHashSim(bucketCount, keyCount, seed) {
+  const random = createGenerator(seed);
+  const classicLoads = Array(bucketCount).fill(0);
+  const choiceLoads = Array(bucketCount).fill(0);
+
+  for (let key = 0; key < keyCount; key += 1) {
+    const classicBucket = Math.floor(random() * bucketCount);
+    classicLoads[classicBucket] += 1;
+
+    const first = Math.floor(random() * bucketCount);
+    const second = Math.floor(random() * bucketCount);
+    const pick = choiceLoads[first] <= choiceLoads[second] ? first : second;
+    choiceLoads[pick] += 1;
+  }
+
+  return {
+    classicLoads,
+    choiceLoads,
+    classicStats: loadStats(classicLoads),
+    choiceStats: loadStats(choiceLoads),
+  };
+}
+
+function BucketBars({ title, loads, colorClass }) {
+  const peak = Math.max(...loads, 1);
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <h3 className="font-semibold mb-3">{title}</h3>
+      <div className="flex items-end gap-[2px] h-36">
+        {loads.map((load, index) => (
+          <div
+            key={`${title}-${index}`}
+            className={`flex-1 ${colorClass} rounded-t-sm`}
+            style={{ height: `${(load / peak) * 100}%` }}
+            title={`Bucket ${index}: ${load}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function LotteryHashDPPage() {
+  const demosHref = process.env.NODE_ENV === 'production' ? '/Demos' : '/';
+  const [bucketCount, setBucketCount] = useState(DEFAULT_BUCKETS);
+  const [keyCount, setKeyCount] = useState(DEFAULT_KEYS);
+  const [seed, setSeed] = useState(DEFAULT_SEED);
+
+  const { classicLoads, choiceLoads, classicStats, choiceStats } = useMemo(
+    () => runHashSim(bucketCount, keyCount, seed),
+    [bucketCount, keyCount, seed]
+  );
+
+  const resetAll = () => {
+    setBucketCount(DEFAULT_BUCKETS);
+    setKeyCount(DEFAULT_KEYS);
+    setSeed(DEFAULT_SEED);
+  };
+
+  return (
+    <main className="min-h-screen p-6 md:p-8 flex flex-col items-center gap-5">
+      <div className="w-full max-w-6xl flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => window.location.assign(demosHref)}
+          className="px-3 py-2 rounded bg-slate-200 hover:bg-slate-300 text-slate-800"
+        >
+          ← Back
+        </button>
+      </div>
+
+      <h1 className="text-3xl md:text-4xl font-bold text-center">Lottery Hash Demo</h1>
+
+      <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">What is this called?</h2>
+        <p className="text-slate-700 mb-3">
+          The breakthrough idea is commonly called the <strong>Power of Two Choices</strong>. Instead of
+          placing each key into one random bucket, we sample two random buckets and choose the less-loaded
+          one.
+        </p>
+        <p className="text-slate-700">
+          This demo names it <strong>Lottery Hashing</strong>: every key draws two lottery tickets (two random
+          buckets), then keeps the better one. A tiny extra choice can dramatically reduce collisions and
+          worst-case bucket spikes.
+        </p>
+      </section>
+
+      <section className="w-full max-w-6xl rounded-xl border border-blue-200 bg-[#eef6ff] p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">How to use</h2>
+        <ul className="list-disc pl-5 space-y-2 text-slate-700">
+          <li>Set how many buckets exist in the hash table.</li>
+          <li>Set how many keys to insert.</li>
+          <li>Change seed to rerun with a different random stream.</li>
+          <li>Compare classic random hashing to Lottery Hashing side-by-side.</li>
+        </ul>
+      </section>
+
+      <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-4">Controls</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold">Buckets: {bucketCount}</span>
+            <input
+              type="range"
+              min="16"
+              max="160"
+              step="8"
+              value={bucketCount}
+              onChange={(event) => setBucketCount(Number.parseInt(event.target.value, 10))}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold">Keys: {keyCount}</span>
+            <input
+              type="range"
+              min="200"
+              max="4000"
+              step="100"
+              value={keyCount}
+              onChange={(event) => setKeyCount(Number.parseInt(event.target.value, 10))}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold">Seed: {seed}</span>
+            <input
+              type="range"
+              min="1"
+              max="300"
+              step="1"
+              value={seed}
+              onChange={(event) => setSeed(Number.parseInt(event.target.value, 10))}
+            />
+          </label>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={resetAll}
+            className="px-4 py-2 rounded bg-slate-800 text-white hover:bg-slate-700"
+          >
+            Reset All
+          </button>
+        </div>
+      </section>
+
+      <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-4">Game / Visualization</h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <BucketBars title="Classic Random Hashing" loads={classicLoads} colorClass="bg-rose-400" />
+          <BucketBars title="Lottery Hashing (2 Choices)" loads={choiceLoads} colorClass="bg-emerald-400" />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-slate-700">
+          <div className="rounded-lg bg-rose-50 border border-rose-100 p-3">
+            <h3 className="font-semibold">Classic stats</h3>
+            <p>Max bucket load: {classicStats.max}</p>
+            <p>Average load: {classicStats.avg.toFixed(2)}</p>
+            <p>Used buckets: {classicStats.used}/{bucketCount}</p>
+            <p>Min load: {classicStats.min}</p>
+          </div>
+          <div className="rounded-lg bg-emerald-50 border border-emerald-100 p-3">
+            <h3 className="font-semibold">Lottery stats</h3>
+            <p>Max bucket load: {choiceStats.max}</p>
+            <p>Average load: {choiceStats.avg.toFixed(2)}</p>
+            <p>Used buckets: {choiceStats.used}/{bucketCount}</p>
+            <p>Min load: {choiceStats.min}</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -60,8 +60,8 @@ export default function Home() {
     },
     {
       route: 'lottery-hash-dp',
-      title: 'Lottery Hash Demo',
-      description: 'Compare classic hashing vs the power-of-two-choices strategy',
+      title: 'Power of Two Choicss Demo',
+      description: 'Compare standard, human-random, and lucky-bucket hashing strategies',
       previewImage: '/lottery-hash-dp-preview.svg',
     },
     {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -48,15 +48,21 @@ export default function Home() {
     },
     {
       route: 'fibonacci-heap-dp',
-      title: 'Fibonacci Heap DP Demo',
+      title: 'Fibonacci Heap Demo',
       description: 'Explore shortest-path DP powered by a Fibonacci heap',
       previewImage: '/fibonacci-heap-dp-preview.svg',
     },
     {
       route: 'floyd-cycle-dp',
-      title: 'Floyd Cycle Detection DP Demo',
+      title: 'Floyd Cycle Detection Demo',
       description: 'Step through tortoise-and-hare state transitions to find cycle entry and length',
       previewImage: '/floyd-cycle-dp-preview.svg',
+    },
+    {
+      route: 'lottery-hash-dp',
+      title: 'Lottery Hash Demo',
+      description: 'Compare classic hashing vs the power-of-two-choices strategy',
+      previewImage: '/lottery-hash-dp-preview.svg',
     },
     {
       route: 'wasm-vs-js',


### PR DESCRIPTION
### Motivation
- Remove the internal phrase styling "DP Demo" from user-facing demo titles so all demo package names are consistent and non-internal.
- Showcase a recent practical hashing improvement (the Power of Two Choices) as a Demo Package and give it a memorable, user-facing name.
- Provide an interactive, visual comparison that makes the performance difference easy to explore for learners and maintainers.

### Description
- Renamed title strings and in-page H1s to remove "DP Demo": updated the home list and pages for Fibonacci Heap and Floyd Cycle (files like `src/app/page.js`, `src/app/fibonacci-heap-dp/page.js`, and `src/app/floyd-cycle-dp/page.js`).
- Added a new demo route `src/app/lottery-hash-dp/page.js` that explains the technique (acknowledged as the _Power of Two Choices_) and presents it under the demo-friendly name **Lottery Hashing** with controls for buckets, keys, and seed.
- Added a preview asset `public/lottery-hash-dp-preview.svg` and wired the new demo into the Demo Packages list so it shows on the homepage.

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors.
- Ran `npm run build` and the Next.js production build completed successfully and listed the new route `/lottery-hash-dp` in the generated routes.
- Launched the dev server and captured automated screenshots via a Playwright script, producing `artifacts/home-updated.png` and `artifacts/lottery-hash-demo.png` to validate the homepage and new demo page rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966725e1f48321a8697c5b65a642ef)