### PR TITLE
Add overlaid red/green strategy occupancy chart and refactor lottery-hash DP

### DIFF
--- a/src/app/lottery-hash-dp/page.js
+++ b/src/app/lottery-hash-dp/page.js
@@ -1,108 +1,264 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-const DEFAULT_BUCKETS = 64;
-const DEFAULT_KEYS = 1200;
-const DEFAULT_SEED = 42;
-const DEFAULT_GAME_ROUNDS = 20;
+const DEFAULT_CONFIG = {
+  buckets: 96,
+  slotsPerBucket: 2,
+  choices: 3,
+  keysToInsert: 170,
+  seed: 42,
+  strategy: 'bubble',
+  showAnimation: true,
+};
+
+const MAX_RELOCATION_STEPS = 80;
+
+function mix32(value) {
+  let x = value >>> 0;
+  x ^= x >>> 16;
+  x = Math.imul(x, 0x7feb352d);
+  x ^= x >>> 15;
+  x = Math.imul(x, 0x846ca68b);
+  x ^= x >>> 16;
+  return x >>> 0;
+}
 
 function createGenerator(seed) {
-  let state = seed >>> 0;
+  let state = mix32(seed || 1);
   return () => {
-    state = (1664525 * state + 1013904223) >>> 0;
-    return state / 2 ** 32;
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 2 ** 32;
   };
 }
 
-function loadStats(loads) {
-  const total = loads.reduce((sum, value) => sum + value, 0);
-  const max = loads.reduce((current, value) => Math.max(current, value), 0);
-  const min = loads.reduce((current, value) => Math.min(current, value), Number.POSITIVE_INFINITY);
-  const used = loads.filter((value) => value > 0).length;
+function hashCandidate(key, i, seed, bucketCount) {
+  return mix32((key + 1) * 0x9e3779b1 ^ (i + 1) * 0x85ebca6b ^ seed * 0xc2b2ae35) % bucketCount;
+}
 
+function uniqueCandidates(key, choiceCount, seed, bucketCount) {
+  const seen = new Set();
+  const result = [];
+  let salt = 0;
+  while (result.length < choiceCount && salt < choiceCount * 4 + 16) {
+    const bucket = hashCandidate(key, result.length + salt, seed, bucketCount);
+    if (!seen.has(bucket)) {
+      seen.add(bucket);
+      result.push(bucket);
+    }
+    salt += 1;
+  }
+  if (result.length === 0) {
+    result.push(0);
+  }
+  return result;
+}
+
+function createTable(bucketCount, slotsPerBucket) {
+  return Array.from({ length: bucketCount }, () => Array(slotsPerBucket).fill(null));
+}
+
+function hasFreeSlot(table, bucket) {
+  return table[bucket].some((slot) => slot === null);
+}
+
+function placeInBucket(table, bucket, key) {
+  const slotIndex = table[bucket].indexOf(null);
+  if (slotIndex === -1) {
+    return false;
+  }
+  table[bucket][slotIndex] = key;
+  return true;
+}
+
+function occupancy(table) {
+  return table.map((bucket) => bucket.filter((slot) => slot !== null).length);
+}
+
+function findBubblingPath(table, startBuckets, choiceCount, seed, bucketCount) {
+  const queue = [...startBuckets];
+  const visited = new Set(startBuckets);
+  const parent = new Map();
+  const visitedOrder = [...startBuckets];
+
+  while (queue.length > 0 && visitedOrder.length <= MAX_RELOCATION_STEPS * 4) {
+    const bucket = queue.shift();
+
+    if (hasFreeSlot(table, bucket)) {
+      return { freeBucket: bucket, parent, visitedOrder };
+    }
+
+    for (const key of table[bucket]) {
+      const candidates = uniqueCandidates(key, choiceCount, seed, bucketCount);
+      for (const altBucket of candidates) {
+        if (altBucket === bucket || visited.has(altBucket)) {
+          continue;
+        }
+        visited.add(altBucket);
+        visitedOrder.push(altBucket);
+        parent.set(altBucket, { from: bucket, key });
+        queue.push(altBucket);
+      }
+    }
+  }
+
+  return null;
+}
+
+function insertKey(table, key, config, rng) {
+  const { buckets, choices, seed, strategy } = config;
+  const candidates = uniqueCandidates(key, choices, seed, buckets);
+
+  for (const bucket of candidates) {
+    if (placeInBucket(table, bucket, key)) {
+      return { success: true, chainLength: 0, visited: [bucket], candidates };
+    }
+  }
+
+  if (strategy === 'bubble') {
+    const pathData = findBubblingPath(table, candidates, choices, seed, buckets);
+    if (!pathData) {
+      return { success: false, chainLength: MAX_RELOCATION_STEPS, visited: candidates, candidates };
+    }
+
+    const path = [];
+    let cursor = pathData.freeBucket;
+    while (pathData.parent.has(cursor)) {
+      const edge = pathData.parent.get(cursor);
+      path.push({ from: edge.from, to: cursor, key: edge.key });
+      cursor = edge.from;
+    }
+
+    const root = cursor;
+    for (let i = path.length - 1; i >= 0; i -= 1) {
+      const { from, to, key: movingKey } = path[i];
+      const slotIndex = table[from].indexOf(movingKey);
+      table[from][slotIndex] = null;
+      placeInBucket(table, to, movingKey);
+    }
+    placeInBucket(table, root, key);
+
+    return {
+      success: true,
+      chainLength: path.length,
+      visited: pathData.visitedOrder,
+      candidates,
+    };
+  }
+
+  let currentKey = key;
+  let currentBucket = candidates[Math.floor(rng() * candidates.length)];
+  const visited = [currentBucket];
+
+  for (let step = 1; step <= MAX_RELOCATION_STEPS; step += 1) {
+    const victimSlot = Math.floor(rng() * table[currentBucket].length);
+    const victim = table[currentBucket][victimSlot];
+    table[currentBucket][victimSlot] = currentKey;
+    currentKey = victim;
+
+    const nextCandidates = uniqueCandidates(currentKey, choices, seed, buckets).filter((bucket) => bucket !== currentBucket);
+    if (nextCandidates.length === 0) {
+      return { success: false, chainLength: step, visited, candidates };
+    }
+
+    currentBucket = nextCandidates[Math.floor(rng() * nextCandidates.length)];
+    visited.push(currentBucket);
+
+    if (placeInBucket(table, currentBucket, currentKey)) {
+      return { success: true, chainLength: step, visited, candidates };
+    }
+  }
+
+  return { success: false, chainLength: MAX_RELOCATION_STEPS, visited, candidates };
+}
+
+function runSimulation(config) {
+  const rng = createGenerator(config.seed);
+  const table = createTable(config.buckets, config.slotsPerBucket);
+  const traces = [];
+  const start = performance.now();
+
+  let failures = 0;
+  let chainTotal = 0;
+  let chainMax = 0;
+  let inserted = 0;
+
+  for (let key = 0; key < config.keysToInsert; key += 1) {
+    const result = insertKey(table, key, config, rng);
+    traces.push({ ...result, key });
+    chainTotal += result.chainLength;
+    chainMax = Math.max(chainMax, result.chainLength);
+
+    if (!result.success) {
+      failures += 1;
+      continue;
+    }
+    inserted += 1;
+  }
+
+  const durationMs = performance.now() - start;
   return {
-    max,
-    min: Number.isFinite(min) ? min : 0,
-    avg: total / loads.length,
-    used,
+    occupancy: occupancy(table),
+    traces,
+    inserted,
+    failures,
+    avgChain: config.keysToInsert === 0 ? 0 : chainTotal / config.keysToInsert,
+    maxChain: chainMax,
+    load: inserted / (config.buckets * config.slotsPerBucket),
+    insertionsPerSecond: durationMs > 0 ? (config.keysToInsert / durationMs) * 1000 : 0,
   };
 }
 
-function pickHumanRandom(random, bucketCount, previousPick, keyIndex) {
-  let pick = Math.floor(random() * bucketCount);
 
-  if (pick === previousPick) {
-    pick = (pick + Math.floor(bucketCount / 3)) % bucketCount;
-  }
-
-  if (keyIndex % 4 === 0) {
-    pick = Math.floor((pick + Math.floor(bucketCount * 0.11)) % bucketCount);
-  }
-
-  if (pick % 2 === 1 && random() > 0.5) {
-    pick -= 1;
-  }
-
-  return Math.max(0, Math.min(bucketCount - 1, pick));
-}
-
-function runHashSim(bucketCount, keyCount, seed) {
-  const random = createGenerator(seed);
-  const classicLoads = Array(bucketCount).fill(0);
-  const humanLoads = Array(bucketCount).fill(0);
-  const choiceLoads = Array(bucketCount).fill(0);
-  let previousHumanPick = -1;
-
-  for (let key = 0; key < keyCount; key += 1) {
-    const classicBucket = Math.floor(random() * bucketCount);
-    classicLoads[classicBucket] += 1;
-
-    const humanBucket = pickHumanRandom(random, bucketCount, previousHumanPick, key);
-    humanLoads[humanBucket] += 1;
-    previousHumanPick = humanBucket;
-
-    const luckyA = Math.floor(random() * bucketCount);
-    const luckyB = Math.floor(random() * bucketCount);
-    const luckyPick = choiceLoads[luckyA] <= choiceLoads[luckyB] ? luckyA : luckyB;
-    choiceLoads[luckyPick] += 1;
-  }
-
-  return {
-    classicLoads,
-    humanLoads,
-    choiceLoads,
-    classicStats: loadStats(classicLoads),
-    humanStats: loadStats(humanLoads),
-    choiceStats: loadStats(choiceLoads),
-  };
-}
-
-function simulateRoundChoices(bucketCount, roundCount, seed) {
-  const random = createGenerator(seed);
-  const rounds = [];
-  for (let round = 0; round < roundCount; round += 1) {
-    rounds.push([
-      Math.floor(random() * bucketCount),
-      Math.floor(random() * bucketCount),
-    ]);
-  }
-  return rounds;
-}
-
-function BucketBars({ title, loads, colorClass }) {
-  const peak = Math.max(...loads, 1);
-
+function OverlayOccupancyComparison({ withoutTechnique, withTechnique, slotsPerBucket }) {
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-4">
-      <h3 className="font-semibold mb-3">{title}</h3>
-      <div className="flex items-end gap-[2px] h-36">
-        {loads.map((load, index) => (
+      <h3 className="font-semibold mb-2">Overlay occupancy comparison (same settings)</h3>
+      <p className="text-sm text-slate-600 mb-3">
+        Red = without technique (naive random-walk). Green = with technique (bubble-up-inspired).
+      </p>
+      <div className="rounded border border-slate-100 bg-slate-50 p-2">
+        <div className="flex items-end gap-[2px] h-44">
+          {withTechnique.map((withValue, index) => {
+            const withoutValue = withoutTechnique[index] ?? 0;
+            return (
+              <div key={`overlay-${index}`} className="relative flex-1 h-full">
+                <div
+                  className="absolute bottom-0 inset-x-0 rounded-t-sm bg-rose-400/80"
+                  style={{ height: `${(withoutValue / Math.max(slotsPerBucket, 1)) * 100}%` }}
+                  title={`Bucket ${index} without technique: ${withoutValue}/${slotsPerBucket}`}
+                />
+                <div
+                  className="absolute bottom-0 inset-x-0 rounded-t-sm bg-emerald-500/70"
+                  style={{ height: `${(withValue / Math.max(slotsPerBucket, 1)) * 100}%` }}
+                  title={`Bucket ${index} with technique: ${withValue}/${slotsPerBucket}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-3 text-sm text-slate-700">
+        <span className="inline-flex items-center gap-1"><span className="inline-block w-3 h-3 rounded bg-rose-400" />Without technique</span>
+        <span className="inline-flex items-center gap-1"><span className="inline-block w-3 h-3 rounded bg-emerald-500" />With technique</span>
+      </div>
+    </div>
+  );
+}
+
+function OccupancyBars({ loads, slotsPerBucket, highlighted }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <h3 className="font-semibold mb-3">Occupancy histogram (per bucket)</h3>
+      <div className="flex items-end gap-[2px] h-44">
+        {loads.map((value, index) => (
           <div
-            key={`${title}-${index}`}
-            className={`flex-1 ${colorClass} rounded-t-sm`}
-            style={{ height: `${(load / peak) * 100}%` }}
-            title={`Lucky bucket ${index}: ${load}`}
+            key={`bucket-${index}`}
+            className={`flex-1 rounded-t-sm ${highlighted.has(index) ? 'bg-indigo-500' : 'bg-emerald-400'}`}
+            style={{ height: `${(value / Math.max(slotsPerBucket, 1)) * 100}%` }}
+            title={`Bucket ${index}: ${value}/${slotsPerBucket}`}
           />
         ))}
       </div>
@@ -112,61 +268,65 @@ function BucketBars({ title, loads, colorClass }) {
 
 export default function LotteryHashDPPage() {
   const demosHref = process.env.NODE_ENV === 'production' ? '/Demos' : '/';
-  const [bucketCount, setBucketCount] = useState(DEFAULT_BUCKETS);
-  const [keyCount, setKeyCount] = useState(DEFAULT_KEYS);
-  const [seed, setSeed] = useState(DEFAULT_SEED);
-  const [gameRound, setGameRound] = useState(0);
-  const [userLoads, setUserLoads] = useState(() => Array(DEFAULT_BUCKETS).fill(0));
-  const [score, setScore] = useState(0);
+  const [config, setConfig] = useState(DEFAULT_CONFIG);
+  const [traceIndex, setTraceIndex] = useState(0);
+  const [animationStep, setAnimationStep] = useState(0);
 
-  const { classicLoads, humanLoads, choiceLoads, classicStats, humanStats, choiceStats } = useMemo(
-    () => runHashSim(bucketCount, keyCount, seed),
-    [bucketCount, keyCount, seed]
+  const sim = useMemo(() => runSimulation(config), [config]);
+  const comparison = useMemo(() => {
+    const shared = {
+      buckets: config.buckets,
+      slotsPerBucket: config.slotsPerBucket,
+      choices: config.choices,
+      keysToInsert: config.keysToInsert,
+      seed: config.seed,
+      showAnimation: false,
+    };
+
+    return {
+      random: runSimulation({ ...shared, strategy: 'random' }),
+      bubble: runSimulation({ ...shared, strategy: 'bubble' }),
+    };
+  }, [config.buckets, config.slotsPerBucket, config.choices, config.keysToInsert, config.seed]);
+
+  const trace = useMemo(
+    () => sim.traces[Math.min(traceIndex, sim.traces.length - 1)] || { visited: [], chainLength: 0, candidates: [] },
+    [sim.traces, traceIndex]
   );
 
-  const gameChoices = useMemo(
-    () => simulateRoundChoices(bucketCount, DEFAULT_GAME_ROUNDS, seed + 777),
-    [bucketCount, seed]
-  );
+  const highlighted = useMemo(() => {
+    if (!config.showAnimation) {
+      return new Set(trace.visited);
+    }
+    return new Set(trace.visited.slice(0, Math.max(animationStep, 1)));
+  }, [trace, animationStep, config.showAnimation]);
 
-  const currentChoices = gameChoices[Math.min(gameRound, DEFAULT_GAME_ROUNDS - 1)] ?? [0, 1];
+  useEffect(() => {
+    setAnimationStep(0);
+  }, [traceIndex, config.showAnimation, config.seed, config.strategy, config.keysToInsert]);
 
-  const resetGame = () => {
-    setGameRound(0);
-    setUserLoads(Array(bucketCount).fill(0));
-    setScore(0);
-  };
-
-  const resetAll = () => {
-    setBucketCount(DEFAULT_BUCKETS);
-    setKeyCount(DEFAULT_KEYS);
-    setSeed(DEFAULT_SEED);
-    setGameRound(0);
-    setUserLoads(Array(DEFAULT_BUCKETS).fill(0));
-    setScore(0);
-  };
-
-  const chooseLuckyBucket = (bucketIndex) => {
-    if (gameRound >= DEFAULT_GAME_ROUNDS) {
-      return;
+  useEffect(() => {
+    if (!config.showAnimation || trace.visited.length <= 1) {
+      return undefined;
     }
 
-    const [luckyA, luckyB] = currentChoices;
+    const timer = setInterval(() => {
+      setAnimationStep((previous) => {
+        if (previous >= trace.visited.length) {
+          return previous;
+        }
+        return previous + 1;
+      });
+    }, 220);
 
-    setUserLoads((previousLoads) => {
-      const nextLoads = [...previousLoads];
-      const betterPick = previousLoads[luckyA] <= previousLoads[luckyB] ? luckyA : luckyB;
-      if (bucketIndex === betterPick) {
-        setScore((previousScore) => previousScore + 1);
-      }
-      nextLoads[bucketIndex] += 1;
-      return nextLoads;
-    });
+    return () => clearInterval(timer);
+  }, [trace, config.showAnimation]);
 
-    setGameRound((previousRound) => previousRound + 1);
+  const resetAll = () => {
+    setConfig(DEFAULT_CONFIG);
+    setTraceIndex(0);
+    setAnimationStep(0);
   };
-
-  const userStats = loadStats(userLoads);
 
   return (
     <main className="min-h-screen p-6 md:p-8 flex flex-col items-center gap-5">
@@ -180,112 +340,202 @@ export default function LotteryHashDPPage() {
         </button>
       </div>
 
-      <h1 className="text-3xl md:text-4xl font-bold text-center">Power of Two Choicss Demo</h1>
+      <h1 className="text-3xl md:text-4xl font-bold text-center">High-Load d-ary Cuckoo Hashing Demo</h1>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-3">Traditional description</h2>
+        <h2 className="text-2xl font-semibold mb-3">What this demo shows</h2>
         <p className="text-slate-700 mb-3">
-          Think of each hash slot as a <strong>lucky bucket</strong>. Standard hashing tosses each key into one
-          random bucket. Power-of-two hashing gives each key two random lucky buckets and picks the one with
-          less traffic.
+          This hash table has a fixed number of buckets, and each bucket has only a few slots. Every key gets a small
+          list of candidate buckets. If all candidates are full, the table tries moving other keys to make room.
+          Near full load, those moves get longer and some inserts fail.
         </p>
-        <p className="text-slate-700">
-          That tiny decision makes heavy collision spikes far less likely. We keep the playful name
-          <strong> Lucky Bucket Draw</strong> in this DP while using the formal computer science term too.
+        <p className="text-slate-700 mb-3">
+          This is different from balls-into-bins load balancing, where bins are treated like unbounded counters.
+          Here we model finite-capacity hash-table placement and relocation behavior as load approaches <strong>1 − ε</strong>.
         </p>
+        <p className="text-slate-700 mb-3">
+          Key takeaway: simple random placement (or weak random eviction) starts failing earlier at high load, while
+          structured relocation keeps inserts working longer. That is the practical point behind the 2025 high-load
+          cuckoo hashing breakthrough.
+        </p>
+
+        <details className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+          <summary className="cursor-pointer font-semibold text-slate-800">Technical explanation + key terms</summary>
+          <div className="mt-3 text-slate-700 space-y-3">
+            <p>
+              We simulate d-ary cuckoo hashing with two insertion policies: a naive random-walk eviction chain and a
+              bubble-up-inspired augmenting-path search. The structured search usually finds shorter chains and keeps
+              failure lower at high load.
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li><strong>N</strong>: number of buckets.</li>
+              <li><strong>b</strong>: slots per bucket.</li>
+              <li><strong>d</strong>: candidate buckets per key.</li>
+              <li><strong>Load factor</strong>: inserted keys / (N × b).</li>
+              <li><strong>Eviction chain</strong>: sequence of relocations needed to insert one key.</li>
+              <li><strong>Failure</strong>: insertion that exceeds relocation step limit.</li>
+              <li><strong>1 − ε high load</strong>: operating very close to full capacity.</li>
+            </ul>
+            <p>
+              Reference: William Kuszmaul and Michael Mitzenmacher (2025),{' '}
+              <a
+                href="https://arxiv.org/abs/2501.02312"
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-700 underline"
+              >
+                Efficient d-ary Cuckoo Hashing at High Load Factors by Bubbling Up (arXiv:2501.02312)
+              </a>
+              .
+            </p>
+          </div>
+        </details>
+      </section>
+
+      <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-4">What the visualization game is showing</h2>
+        <p className="text-slate-700 mb-3">
+          Think of each insertion as a small puzzle: can we place one more key using only its <strong>d</strong> candidate
+          buckets? The chart and trace viewer show how hard that puzzle gets as the table fills.
+        </p>
+        <ul className="list-disc pl-5 space-y-1 text-slate-700">
+          <li>Green/indigo bars show per-bucket occupancy from 0 to <strong>b</strong> slots.</li>
+          <li>The metrics show whether we are still inserting smoothly or hitting failures.</li>
+          <li>
+            The eviction-chain viewer shows the bucket path visited during one insertion attempt (a short chain is good,
+            long chains signal high pressure).
+          </li>
+        </ul>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-blue-200 bg-[#eef6ff] p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-3">How to play</h2>
+        <h2 className="text-2xl font-semibold mb-4">How to play</h2>
         <ul className="list-disc pl-5 space-y-2 text-slate-700">
-          <li>Set how many lucky buckets exist in the hash table.</li>
-          <li>Set how many keys to insert for the large simulation.</li>
-          <li>Change seed to rerun with a different pseudo-random stream.</li>
-          <li>Compare Standard Random, Human Random, and Lucky Bucket Draw (power of two choices).</li>
-          <li>In the mini-game, pick between two lucky buckets and try to beat your own balancing score.</li>
+          <li>Set <strong>N</strong>, <strong>b</strong>, <strong>d</strong>, and <strong>K</strong> to choose table pressure.</li>
+          <li>
+            Use <strong>Strategy</strong> to switch between naive random-walk eviction and bubble-up-inspired relocation.
+          </li>
+          <li>
+            Check the <strong>Strategy snapshot</strong> card to see both strategies compared on the same settings.
+          </li>
+          <li>
+            In <strong>Simulation Output</strong>, move the insertion trace slider to inspect a specific eviction chain.
+          </li>
+          <li>
+            Push <strong>K</strong> toward <strong>N × b</strong> (or slightly above) to observe longer chains and failures.
+          </li>
         </ul>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-3">Technical explanation</h2>
+        <h2 className="text-2xl font-semibold mb-4">Strategy snapshot (same settings)</h2>
         <p className="text-slate-700 mb-3">
-          In classic balls-into-bins hashing, the heaviest bucket grows with about
-          <strong> log n / log log n</strong>. With the power of two choices, the maximum load collapses to about
-          <strong> log log n</strong> (plus a small constant), which is an exponential improvement in tail behavior.
-          In practice this means fewer pathological hot buckets, lower lock contention, and tighter latency
-          distributions under high throughput.
+          This quick comparison uses the current N, b, d, K, and seed for both strategies so you can see why structured
+          relocation matters more than random behavior near full load.
         </p>
-        <p className="text-slate-700 mb-3">
-          The intuition: each key gets two independent opportunities. Picking the less-loaded option applies
-          negative feedback to hotspots, so overloaded buckets become less likely to receive additional keys.
-          Over many inserts this creates a self-balancing effect that plain one-choice random placement cannot
-          reproduce.
-        </p>
-        <p className="text-slate-700">
-          APA source: Mitzenmacher, M. (2001). The power of two choices in randomized load balancing.
-          <em> IEEE Transactions on Parallel and Distributed Systems, 12</em>(10), 1094-1104.
-          {' '}
-          <a
-            href="https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf"
-            target="_blank"
-            rel="noreferrer"
-            className="text-blue-700 underline"
-          >
-            https://www.eecs.harvard.edu/~michaelm/postscripts/tpds2001.pdf
-          </a>
-        </p>
+        <OverlayOccupancyComparison
+          withoutTechnique={comparison.random.occupancy}
+          withTechnique={comparison.bubble.occupancy}
+          slotsPerBucket={config.slotsPerBucket}
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="rounded border border-rose-200 bg-rose-50 p-4 text-slate-700">
+            <h3 className="font-semibold mb-2">Naive random-walk eviction</h3>
+            <p>Load: {comparison.random.load.toFixed(3)}</p>
+            <p>Failures: {comparison.random.failures}</p>
+            <p>Avg chain: {comparison.random.avgChain.toFixed(2)}</p>
+            <p>Max chain: {comparison.random.maxChain}</p>
+          </div>
+          <div className="rounded border border-emerald-200 bg-emerald-50 p-4 text-slate-700">
+            <h3 className="font-semibold mb-2">Bubble-up-inspired</h3>
+            <p>Load: {comparison.bubble.load.toFixed(3)}</p>
+            <p>Failures: {comparison.bubble.failures}</p>
+            <p>Avg chain: {comparison.bubble.avgChain.toFixed(2)}</p>
+            <p>Max chain: {comparison.bubble.maxChain}</p>
+          </div>
+        </div>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-2xl font-semibold mb-4">Controls</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <label className="flex flex-col gap-2">
-            <span className="font-semibold">Lucky Buckets: {bucketCount}</span>
+            <span className="font-semibold">Buckets N: {config.buckets}</span>
             <input
               type="range"
               min="16"
-              max="160"
-              step="8"
-              value={bucketCount}
-              onChange={(event) => {
-                const next = Number.parseInt(event.target.value, 10);
-                setBucketCount(next);
-                setUserLoads(Array(next).fill(0));
-                setGameRound(0);
-                setScore(0);
-              }}
+              max="512"
+              step="16"
+              value={config.buckets}
+              onChange={(event) => setConfig((value) => ({ ...value, buckets: Number.parseInt(event.target.value, 10) }))}
             />
           </label>
-
           <label className="flex flex-col gap-2">
-            <span className="font-semibold">Keys: {keyCount}</span>
+            <span className="font-semibold">Slots per bucket b: {config.slotsPerBucket}</span>
             <input
               type="range"
-              min="200"
-              max="4000"
-              step="100"
-              value={keyCount}
-              onChange={(event) => setKeyCount(Number.parseInt(event.target.value, 10))}
+              min="1"
+              max="8"
+              step="1"
+              value={config.slotsPerBucket}
+              onChange={(event) => setConfig((value) => ({ ...value, slotsPerBucket: Number.parseInt(event.target.value, 10) }))}
             />
           </label>
-
           <label className="flex flex-col gap-2">
-            <span className="font-semibold">Seed: {seed}</span>
+            <span className="font-semibold">Choices per key d: {config.choices}</span>
+            <input
+              type="range"
+              min="2"
+              max="16"
+              step="1"
+              value={config.choices}
+              onChange={(event) => setConfig((value) => ({ ...value, choices: Number.parseInt(event.target.value, 10) }))}
+            />
+          </label>
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold">Keys to insert K: {config.keysToInsert}</span>
+            <input
+              type="range"
+              min="32"
+              max={Math.floor(config.buckets * config.slotsPerBucket * 1.1)}
+              step="1"
+              value={Math.min(config.keysToInsert, Math.floor(config.buckets * config.slotsPerBucket * 1.1))}
+              onChange={(event) => setConfig((value) => ({ ...value, keysToInsert: Number.parseInt(event.target.value, 10) }))}
+            />
+          </label>
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold">Seed: {config.seed}</span>
             <input
               type="range"
               min="1"
               max="300"
               step="1"
-              value={seed}
-              onChange={(event) => {
-                setSeed(Number.parseInt(event.target.value, 10));
-                setUserLoads(Array(bucketCount).fill(0));
-                setGameRound(0);
-                setScore(0);
-              }}
+              value={config.seed}
+              onChange={(event) => setConfig((value) => ({ ...value, seed: Number.parseInt(event.target.value, 10) }))}
             />
           </label>
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold">Strategy</span>
+            <select
+              className="rounded border border-slate-300 px-2 py-2"
+              value={config.strategy}
+              onChange={(event) => setConfig((value) => ({ ...value, strategy: event.target.value }))}
+            >
+              <option value="random">Naive random-walk eviction</option>
+              <option value="bubble">Bubble-up-inspired augmenting path</option>
+            </select>
+          </label>
         </div>
+
+        <label className="mt-4 flex items-center gap-2 text-slate-700">
+          <input
+            type="checkbox"
+            checked={config.showAnimation}
+            onChange={(event) => setConfig((value) => ({ ...value, showAnimation: event.target.checked }))}
+          />
+          Show eviction animation
+        </label>
 
         <div className="mt-4 flex flex-wrap gap-3">
           <button
@@ -295,83 +545,69 @@ export default function LotteryHashDPPage() {
           >
             Reset All
           </button>
-          <button
-            type="button"
-            onClick={resetGame}
-            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500"
-          >
-            Reset Mini-Game
-          </button>
         </div>
       </section>
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-4">Game / Visualization</h2>
+        <h2 className="text-2xl font-semibold mb-4">Simulation Output</h2>
+        <OccupancyBars loads={sim.occupancy} slotsPerBucket={config.slotsPerBucket} highlighted={highlighted} />
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-          <BucketBars title="Standard Random Hash" loads={classicLoads} colorClass="bg-rose-400" />
-          <BucketBars title="Human Random Hash" loads={humanLoads} colorClass="bg-amber-400" />
-          <BucketBars title="Lucky Bucket Draw (Power of Two)" loads={choiceLoads} colorClass="bg-emerald-400" />
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-3 text-slate-700 mt-4">
+          <div className="rounded bg-emerald-50 border border-emerald-100 p-3">
+            <p className="font-semibold">Load factor</p>
+            <p>{sim.load.toFixed(3)}</p>
+          </div>
+          <div className="rounded bg-rose-50 border border-rose-100 p-3">
+            <p className="font-semibold">Failures</p>
+            <p>{sim.failures}</p>
+          </div>
+          <div className="rounded bg-indigo-50 border border-indigo-100 p-3">
+            <p className="font-semibold">Avg chain</p>
+            <p>{sim.avgChain.toFixed(2)}</p>
+          </div>
+          <div className="rounded bg-indigo-50 border border-indigo-100 p-3">
+            <p className="font-semibold">Max chain</p>
+            <p>{sim.maxChain}</p>
+          </div>
+          <div className="rounded bg-slate-50 border border-slate-200 p-3">
+            <p className="font-semibold">Insertions/s</p>
+            <p>{sim.insertionsPerSecond.toFixed(0)}</p>
+          </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-slate-700 mb-4">
-          <div className="rounded-lg bg-rose-50 border border-rose-100 p-3">
-            <h3 className="font-semibold">Standard stats</h3>
-            <p>Max load: {classicStats.max}</p>
-            <p>Average: {classicStats.avg.toFixed(2)}</p>
-          </div>
-          <div className="rounded-lg bg-amber-50 border border-amber-100 p-3">
-            <h3 className="font-semibold">Human random stats</h3>
-            <p>Max load: {humanStats.max}</p>
-            <p>Average: {humanStats.avg.toFixed(2)}</p>
-          </div>
-          <div className="rounded-lg bg-emerald-50 border border-emerald-100 p-3">
-            <h3 className="font-semibold">Power of two stats</h3>
-            <p>Max load: {choiceStats.max}</p>
-            <p>Average: {choiceStats.avg.toFixed(2)}</p>
-          </div>
-        </div>
-
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-          <h3 className="font-semibold mb-2">Mini-game: pick the better lucky bucket</h3>
-          <p className="text-slate-700 mb-3">
-            Round {Math.min(gameRound + 1, DEFAULT_GAME_ROUNDS)} / {DEFAULT_GAME_ROUNDS} · Score: {score}
+        <div className="mt-4 rounded border border-slate-200 bg-slate-50 p-4">
+          <h3 className="font-semibold mb-2">Eviction chain viewer</h3>
+          <label className="flex flex-col gap-2">
+            <span className="text-sm text-slate-700">Insertion trace index: {traceIndex}</span>
+            <input
+              type="range"
+              min="0"
+              max={Math.max(sim.traces.length - 1, 0)}
+              value={Math.min(traceIndex, Math.max(sim.traces.length - 1, 0))}
+              onChange={(event) => setTraceIndex(Number.parseInt(event.target.value, 10))}
+            />
+          </label>
+          <p className="text-slate-700 mt-2">
+            Key #{trace.key ?? 0} · success: {trace.success ? 'yes' : 'no'} · chain length: {trace.chainLength}
           </p>
-          {gameRound >= DEFAULT_GAME_ROUNDS ? (
-            <p className="text-slate-700">Game complete. Reset Mini-Game to play again with the same settings.</p>
-          ) : (
-            <div className="flex flex-wrap gap-3">
-              <button
-                type="button"
-                className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-500"
-                onClick={() => chooseLuckyBucket(currentChoices[0])}
-              >
-                Choose lucky bucket #{currentChoices[0]}
-              </button>
-              <button
-                type="button"
-                className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-500"
-                onClick={() => chooseLuckyBucket(currentChoices[1])}
-              >
-                Choose lucky bucket #{currentChoices[1]}
-              </button>
-            </div>
-          )}
-          <p className="text-sm text-slate-600 mt-3">
-            Tip: You gain a point when you pick the less-loaded bucket between the two offered choices.
+          <p className="text-sm text-slate-600 mt-1">
+            Candidates: {trace.candidates?.join(', ') || 'n/a'} · visited buckets: {trace.visited?.join(' → ') || 'n/a'}
           </p>
-          <div className="mt-3 rounded bg-white border border-slate-200 p-3">
-            <p className="font-semibold mb-2">Your mini-game bucket balance</p>
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-8 gap-2 text-xs">
-              {userLoads.slice(0, Math.min(bucketCount, 32)).map((value, index) => (
-                <div key={`user-load-${index}`} className="rounded bg-slate-100 p-2 text-center">
-                  #{index}: {value}
-                </div>
-              ))}
-            </div>
-            <p className="text-sm text-slate-700 mt-2">Your max load so far: {userStats.max}</p>
-          </div>
         </div>
+      </section>
+
+      <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">How to implement</h2>
+        <ul className="list-disc pl-6 text-slate-700 space-y-1">
+          <li>Store a table as <code>buckets[N][b]</code>, where each slot is empty or contains a key id.</li>
+          <li>For each key, compute <code>d</code> candidate buckets with seeded hash functions and mod by <code>N</code>.</li>
+          <li>
+            Insertion: place directly if any candidate has free space; otherwise run relocation (random walk or
+            augmenting-path search) with a max-step cutoff.
+          </li>
+          <li>Track and display load factor, failures, average/max chain length, and throughput.</li>
+          <li>Use a seeded PRNG so changing only strategy keeps runs reproducible.</li>
+        </ul>
       </section>
     </main>
   );

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -60,8 +60,8 @@ export default function Home() {
     },
     {
       route: 'lottery-hash-dp',
-      title: 'Power of Two Choicss Demo',
-      description: 'Compare standard, human-random, and lucky-bucket hashing strategies',
+      title: 'High-Load Cuckoo Hashing Demo',
+      description: 'Explore selective-bucket cuckoo hashing near full capacity',
       previewImage: '/lottery-hash-dp-preview.svg',
     },
     {


### PR DESCRIPTION
### Motivation
- Improve visual clarity of the strategy comparison so users can see both occupancy profiles on the same bucket axis (green = with technique, red = without) as requested. 
- Bring the Lottery/lottery-hash demo in line with the DP style used across the repo by consolidating simulation config and exposing reproducible controls. 
- Surface comparable metrics (load, failures, avg/max chain) alongside the overlay so the visual and numerical summaries match the same settings.

### Description
- Added a new `OverlayOccupancyComparison` React component that draws both strategy occupancies stacked/overlaid per bucket using red for the naive/random strategy and green for the bubble-up strategy, and integrated it into the "Strategy snapshot (same settings)" section. (file: `src/app/lottery-hash-dp/page.js`)
- Refactored the page to use a single `DEFAULT_CONFIG` object and unified simulation code paths with a seeded PRNG, `runSimulation`, `insertKey`, and helper functions (`uniqueCandidates`, `createTable`, `occupancy`, etc.) to support both `random` and `bubble` strategies. (file: `src/app/lottery-hash-dp/page.js`)
- Replaced older per-demo variables and removed the mini-game in favor of a focused simulation UI: controls for `N`, `b`, `d`, `K`, `seed`, `strategy`, and `showAnimation`; an occupancy histogram with highlightable visited buckets; an eviction chain viewer; and metric cards. (file: `src/app/lottery-hash-dp/page.js`)
- Kept the existing side-by-side metric cards but added the overlay above them and updated copy/titles to match the DP wording. (files: `src/app/lottery-hash-dp/page.js`, `src/app/page.js`)
- Minor site nav metadata update to rename the demo entry to "High-Load Cuckoo Hashing Demo" for clarity. (file: `src/app/page.js`)

### Testing
- Ran automated linting with `npm run lint` and received no ESLint warnings or errors (success).
- Built the app with `npm run build` which completed successfully and produced the optimized build (success).
- Launched the dev server and captured screenshots for visual verification using Playwright; screenshots saved as `artifacts/cuckoo-overlay-graph-default.png` and `artifacts/cuckoo-overlay-graph-with-technical-open.png` (dev server started and screenshots taken successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967a52840c8321b2555bc140f9feff)