### PR TITLE
Add interactive Slitherlink demo (9x9) with preview image

### DIFF
--- a/public/slitherlink-preview.svg
+++ b/public/slitherlink-preview.svg
@@ -1,0 +1,12 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" fill="#E2E8F0"/>
+  <rect x="250" y="80" width="700" height="470" rx="24" fill="#F8FAFC" stroke="#94A3B8" stroke-width="4"/>
+  <g stroke="#334155" stroke-width="4" fill="none">
+    <path d="M360 170H840"/><path d="M360 250H840"/><path d="M360 330H840"/><path d="M360 410H840"/><path d="M360 490H840"/>
+    <path d="M360 170V490"/><path d="M460 170V490"/><path d="M560 170V490"/><path d="M660 170V490"/><path d="M760 170V490"/><path d="M840 170V490"/>
+  </g>
+  <g stroke="#0284C7" stroke-width="10" stroke-linecap="round">
+    <path d="M360 170H560V330H760V490H460V250H360"/>
+  </g>
+  <text x="600" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="44" font-weight="700" fill="#0F172A">Slitherlink</text>
+</svg>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -143,6 +143,12 @@ export default function Home() {
       description: 'Place rising values into circles and win with the lowest black-hole sum',
       previewImage: '/black-hole-preview.svg',
     },
+    {
+      route: 'slitherlink',
+      title: 'Slitherlink',
+      description: 'Draw a single loop that satisfies numbered clues on a 9x9 grid',
+      previewImage: '/slitherlink-preview.svg',
+    },
   ];
 
   return (

--- a/src/app/slitherlink/page.js
+++ b/src/app/slitherlink/page.js
@@ -1,0 +1,206 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const SIZE = 9;
+
+function randomInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function buildRectangleLoop() {
+  const minSpan = 3;
+  const maxStart = SIZE - minSpan;
+  const top = randomInt(maxStart);
+  const left = randomInt(maxStart);
+  const bottom = top + minSpan + randomInt(SIZE - top - minSpan + 1);
+  const right = left + minSpan + randomInt(SIZE - left - minSpan + 1);
+
+  const horizontal = Array.from({ length: SIZE + 1 }, () => Array.from({ length: SIZE }, () => false));
+  const vertical = Array.from({ length: SIZE }, () => Array.from({ length: SIZE + 1 }, () => false));
+
+  for (let col = left; col < right; col += 1) {
+    horizontal[top][col] = true;
+    horizontal[bottom][col] = true;
+  }
+
+  for (let row = top; row < bottom; row += 1) {
+    vertical[row][left] = true;
+    vertical[row][right] = true;
+  }
+
+  return { horizontal, vertical };
+}
+
+function countCellEdges(edges, row, col) {
+  let count = 0;
+  if (edges.horizontal[row][col]) count += 1;
+  if (edges.horizontal[row + 1][col]) count += 1;
+  if (edges.vertical[row][col]) count += 1;
+  if (edges.vertical[row][col + 1]) count += 1;
+  return count;
+}
+
+function createPuzzleFromSolution(solutionEdges) {
+  const clues = Array.from({ length: SIZE }, () => Array.from({ length: SIZE }, () => ''));
+
+  for (let row = 0; row < SIZE; row += 1) {
+    for (let col = 0; col < SIZE; col += 1) {
+      const count = countCellEdges(solutionEdges, row, col);
+      if (Math.random() < 0.55) clues[row][col] = String(count);
+    }
+  }
+
+  return clues;
+}
+
+function createEmptyEdges() {
+  return {
+    horizontal: Array.from({ length: SIZE + 1 }, () => Array.from({ length: SIZE }, () => false)),
+    vertical: Array.from({ length: SIZE }, () => Array.from({ length: SIZE + 1 }, () => false)),
+  };
+}
+
+function createPuzzleState() {
+  const solution = buildRectangleLoop();
+  return {
+    clues: createPuzzleFromSolution(solution),
+    edges: createEmptyEdges(),
+  };
+}
+
+function getVertexDegrees(edges) {
+  const degrees = Array.from({ length: SIZE + 1 }, () => Array.from({ length: SIZE + 1 }, () => 0));
+
+  for (let row = 0; row < SIZE + 1; row += 1) {
+    for (let col = 0; col < SIZE; col += 1) {
+      if (edges.horizontal[row][col]) {
+        degrees[row][col] += 1;
+        degrees[row][col + 1] += 1;
+      }
+    }
+  }
+
+  for (let row = 0; row < SIZE; row += 1) {
+    for (let col = 0; col < SIZE + 1; col += 1) {
+      if (edges.vertical[row][col]) {
+        degrees[row][col] += 1;
+        degrees[row + 1][col] += 1;
+      }
+    }
+  }
+
+  return degrees;
+}
+
+export default function SlitherlinkPage() {
+  const demosHref = process.env.NODE_ENV === 'production' ? '/Demos' : '/';
+  const [state, setState] = useState(() => createPuzzleState());
+
+  const clueStatus = useMemo(() => {
+    let satisfied = 0;
+    let clueCount = 0;
+
+    for (let row = 0; row < SIZE; row += 1) {
+      for (let col = 0; col < SIZE; col += 1) {
+        const clue = state.clues[row][col];
+        if (clue === '') continue;
+        clueCount += 1;
+        if (countCellEdges(state.edges, row, col) === Number(clue)) satisfied += 1;
+      }
+    }
+
+    return { satisfied, clueCount };
+  }, [state]);
+
+  const loopStatus = useMemo(() => {
+    const degrees = getVertexDegrees(state.edges);
+    let openVertices = 0;
+    let usedVertices = 0;
+
+    for (let row = 0; row < SIZE + 1; row += 1) {
+      for (let col = 0; col < SIZE + 1; col += 1) {
+        const degree = degrees[row][col];
+        if (degree === 1 || degree > 2) openVertices += 1;
+        if (degree > 0) usedVertices += 1;
+      }
+    }
+
+    if (usedVertices === 0) return 'Start drawing a loop.';
+    if (openVertices > 0) return `Loop has ${openVertices} invalid vertex${openVertices === 1 ? '' : 'es'}.`;
+    return 'All active vertices have degree 2 (loop-like shape).';
+  }, [state]);
+
+  function toggleHorizontal(row, col) {
+    setState((prev) => {
+      const horizontal = prev.edges.horizontal.map((line) => [...line]);
+      horizontal[row][col] = !horizontal[row][col];
+      return { ...prev, edges: { ...prev.edges, horizontal } };
+    });
+  }
+
+  function toggleVertical(row, col) {
+    setState((prev) => {
+      const vertical = prev.edges.vertical.map((line) => [...line]);
+      vertical[row][col] = !vertical[row][col];
+      return { ...prev, edges: { ...prev.edges, vertical } };
+    });
+  }
+
+  function newPuzzle() {
+    setState(createPuzzleState());
+  }
+
+  return (
+    <main className="min-h-screen p-6 md:p-8 flex flex-col items-center gap-5">
+      <div className="w-full max-w-5xl flex items-center justify-between">
+        <button type="button" onClick={() => window.location.assign(demosHref)} className="px-3 py-2 rounded bg-slate-200 hover:bg-slate-300 text-slate-800">← Back</button>
+      </div>
+      <h1 className="text-3xl font-bold text-center">Slitherlink Demo</h1>
+
+      <section className="w-full max-w-5xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">How to play</h2>
+        <ul className="list-disc pl-5 space-y-2 text-slate-700">
+          <li>Click line segments to draw your loop.</li>
+          <li>Each clue says exactly how many sides of that cell are in the loop.</li>
+          <li>Loops cannot branch or end; every used dot should have degree 2.</li>
+        </ul>
+      </section>
+
+      <div className="rounded-xl bg-slate-50 p-4 shadow-inner overflow-auto">
+        <div className="relative" style={{ width: SIZE * 44 + 1, height: SIZE * 44 + 1 }}>
+          {Array.from({ length: SIZE + 1 }).map((_, row) =>
+            Array.from({ length: SIZE }).map((__, col) => (
+              <button key={`h-${row}-${col}`} type="button" onClick={() => toggleHorizontal(row, col)} className={`absolute h-2 rounded-full ${state.edges.horizontal[row][col] ? 'bg-sky-600' : 'bg-slate-200 hover:bg-slate-400'}`} style={{ top: row * 44 - 4, left: col * 44 + 4, width: 36 }} />
+            ))
+          )}
+
+          {Array.from({ length: SIZE }).map((_, row) =>
+            Array.from({ length: SIZE + 1 }).map((__, col) => (
+              <button key={`v-${row}-${col}`} type="button" onClick={() => toggleVertical(row, col)} className={`absolute w-2 rounded-full ${state.edges.vertical[row][col] ? 'bg-sky-600' : 'bg-slate-200 hover:bg-slate-400'}`} style={{ top: row * 44 + 4, left: col * 44 - 4, height: 36 }} />
+            ))
+          )}
+
+          {Array.from({ length: SIZE + 1 }).map((_, row) =>
+            Array.from({ length: SIZE + 1 }).map((__, col) => (
+              <div key={`d-${row}-${col}`} className="absolute h-3 w-3 rounded-full bg-slate-800" style={{ top: row * 44 - 6, left: col * 44 - 6 }} />
+            ))
+          )}
+
+          {state.clues.map((row, rowIndex) =>
+            row.map((clue, colIndex) => {
+              if (clue === '') return null;
+              const isSatisfied = countCellEdges(state.edges, rowIndex, colIndex) === Number(clue);
+              return <div key={`c-${rowIndex}-${colIndex}`} className={`absolute text-lg font-semibold ${isSatisfied ? 'text-emerald-600' : 'text-slate-700'}`} style={{ top: rowIndex * 44 + 10, left: colIndex * 44 + 16 }}>{clue}</div>;
+            })
+          )}
+        </div>
+      </div>
+
+      <p className="font-medium">Satisfied clues: {clueStatus.satisfied}/{clueStatus.clueCount}</p>
+      <p className="text-slate-700">{loopStatus}</p>
+
+      <button type="button" className="px-4 py-2 rounded bg-slate-900 text-white hover:bg-slate-700" onClick={newPuzzle}>New Puzzle</button>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Add a new Slitherlink demo to the Ckplace demos to showcase an interactive puzzle UI. 
- Provide a self-contained playable 9x9 Slitherlink that demonstrates clue checking and loop validation in the browser. 
- Use a simple puzzle generator to create approachable puzzles for the demo.

### Description
- Added a new interactive page at `src/app/slitherlink/page.js` that implements a client-side Slitherlink UI, state management, edge toggling, clue satisfaction counting, and loop-degree diagnostics. 
- Implemented puzzle generation utilities inside the page including `buildRectangleLoop`, `createPuzzleFromSolution`, `createEmptyEdges`, and `getVertexDegrees` to synthesize puzzles and compute edge/clue state. 
- Added a preview SVG at `public/slitherlink-preview.svg` for the demo card. 
- Registered the Slitherlink demo in the demo list by updating `src/app/page.js` to include the `slitherlink` route, title, description, and `previewImage` reference.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6173716748321be82e01f10a2015c)