### PR TITLE
Unify instruction styling; highlight Hex winning path; add Black Hole AI (Gold)

### DIFF
--- a/src/app/black-hole/page.js
+++ b/src/app/black-hole/page.js
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const PLAYER_CONFIGS = {
   2: [
     { key: 'red', label: 'Red' },
-    { key: 'blue', label: 'Blue' },
+    { key: 'gold', label: 'Gold' },
   ],
   3: [
     { key: 'red', label: 'Red' },
@@ -22,12 +22,12 @@ const COLOR_STYLES = {
     winnerRing: 'ring-red-500/95',
     winnerGlow: 'shadow-[0_0_26px_rgba(239,68,68,0.75)]',
   },
-  blue: {
-    ring: 'ring-blue-500',
-    number: 'text-blue-700',
-    fill: 'bg-blue-100',
-    winnerRing: 'ring-blue-500/95',
-    winnerGlow: 'shadow-[0_0_26px_rgba(59,130,246,0.75)]',
+  gold: {
+    ring: 'ring-amber-500',
+    number: 'text-amber-700',
+    fill: 'bg-amber-100',
+    winnerRing: 'ring-amber-500/95',
+    winnerGlow: 'shadow-[0_0_26px_rgba(245,158,11,0.75)]',
   },
   green: {
     ring: 'ring-emerald-500',
@@ -62,7 +62,7 @@ function getNeighbors(row, col, height) {
   return candidates.filter(([r, c]) => r >= 0 && r < height && c >= 0 && c <= r);
 }
 
-function initialState(playerCount) {
+function initialState(playerCount, aiEnabled = false) {
   const players = PLAYER_CONFIGS[playerCount];
   const height = playerCount === 2 ? 6 : 7;
   const nextValues = Object.fromEntries(players.map((player) => [player.key, 1]));
@@ -81,6 +81,9 @@ function initialState(playerCount) {
     connectedCells: [],
     scores: Object.fromEntries(players.map((player) => [player.key, 0])),
     winnerKeys: [],
+    aiCandidateIds: [],
+    aiThinking: false,
+    aiEnabled,
   };
 }
 
@@ -88,7 +91,9 @@ export default function BlackHolePage() {
   const demosHref = process.env.NODE_ENV === 'production' ? '/Demos' : '/';
   const [playerCount, setPlayerCount] = useState(2);
   const [started, setStarted] = useState(false);
-  const [state, setState] = useState(() => initialState(2));
+  const [aiEnabled, setAiEnabled] = useState(true);
+  const [state, setState] = useState(() => initialState(2, true));
+  const aiTimerRef = useRef(null);
 
   useEffect(() => {
     document.title = 'Black Hole';
@@ -147,18 +152,18 @@ export default function BlackHolePage() {
   }, [state.blackHole, state.connectedCells, state.gameOver, state.height]);
 
   function startGame() {
-    setState(initialState(playerCount));
+    setState(initialState(playerCount, aiEnabled));
     setStarted(true);
   }
 
   function resetGame() {
     if (!window.confirm('Are you sure you want to start a new game?')) return;
-    setState(initialState(playerCount));
+    setState(initialState(playerCount, aiEnabled));
     setStarted(false);
   }
 
   function handleCellClick(cell) {
-    if (!started || state.gameOver || cell.move) return;
+    if (!started || state.gameOver || cell.move || (state.aiEnabled && currentPlayer.key === 'gold')) return;
 
     setState((prev) => {
       if (prev.selected?.id === cell.id) {
@@ -232,9 +237,70 @@ export default function BlackHolePage() {
         turnIndex: (prev.turnIndex + 1) % prev.playerCount,
         selected: null,
         hovered: null,
+        aiCandidateIds: [],
+        aiThinking: false,
       };
     });
   }
+
+
+
+  useEffect(() => {
+    if (aiTimerRef.current) {
+      clearTimeout(aiTimerRef.current);
+      aiTimerRef.current = null;
+    }
+
+    if (!started || state.gameOver || !state.aiEnabled || currentPlayer.key !== 'gold') return;
+
+    const open = state.board.flat().filter((cell) => !cell.move);
+    if (open.length === 0) return;
+
+    const scored = open
+      .map((cell) => {
+        const neighbors = getNeighbors(cell.row, cell.col, state.height).map(([r, c]) => state.board[r][c]);
+        const occupied = neighbors.filter((neighbor) => neighbor.move);
+        const score = occupied.reduce((sum, entry) => sum + entry.move.value, 0) + occupied.length * 0.8 + Math.random() * 0.01;
+        return { cell, score };
+      })
+      .sort((a, b) => a.score - b.score);
+
+    const topThree = scored.slice(0, 3).map((entry) => entry.cell.id);
+    const choice = scored[0].cell;
+
+    setState((prev) => ({ ...prev, aiCandidateIds: topThree, aiThinking: true }));
+
+    aiTimerRef.current = setTimeout(() => {
+      setState((prev) => {
+        if (prev.gameOver) return prev;
+        const player = prev.players[prev.turnIndex];
+        const placement = prev.nextValues[player.key];
+        const nextBoard = prev.board.map((row) =>
+          row.map((cell) => (cell.id === choice.id
+            ? { ...cell, move: { playerKey: player.key, playerLabel: player.label, value: placement } }
+            : cell)),
+        );
+        const nextValues = { ...prev.nextValues, [player.key]: placement + 1 };
+        const nextOpen = nextBoard.flat().filter((cell) => !cell.move);
+        if (nextOpen.length === 1) {
+          const blackHole = nextOpen[0];
+          const connectedCells = getNeighbors(blackHole.row, blackHole.col, prev.height)
+            .map(([row, col]) => nextBoard[row][col])
+            .filter((cell) => cell.move);
+          const scores = Object.fromEntries(prev.players.map((entry) => [entry.key, 0]));
+          for (const connected of connectedCells) scores[connected.move.playerKey] += connected.move.value;
+          const lowest = Math.min(...Object.values(scores));
+          const winnerKeys = prev.players.map((entry) => entry.key).filter((key) => scores[key] === lowest);
+          return { ...prev, board: nextBoard, nextValues, selected: null, hovered: null, aiCandidateIds: [], aiThinking: false, gameOver: true, blackHole, connectedCells, scores, winnerKeys };
+        }
+        return { ...prev, board: nextBoard, nextValues, turnIndex: (prev.turnIndex + 1) % prev.playerCount, selected: null, hovered: null, aiCandidateIds: [], aiThinking: false };
+      });
+    }, 1500);
+
+    return () => {
+      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+    };
+  }, [started, state.board, state.gameOver, state.aiEnabled, currentPlayer.key, state.height]);
 
   return (
     <main className="min-h-screen p-6 md:p-8 flex flex-col items-center gap-6">
@@ -288,6 +354,13 @@ export default function BlackHolePage() {
             <option value={3}>3 players</option>
           </select>
 
+          {!started && playerCount === 2 && (
+            <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+              <input type="checkbox" checked={aiEnabled} onChange={(event) => setAiEnabled(event.target.checked)} />
+              Play vs AI (Gold)
+            </label>
+          )}
+
           {!started && (
             <button
               type="button"
@@ -312,6 +385,9 @@ export default function BlackHolePage() {
 
       <section className="w-full max-w-6xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm flex flex-col items-center gap-4">
         <p className="text-lg font-semibold text-slate-800">{statusText}</p>
+        {started && state.aiEnabled && currentPlayer.key === 'gold' && (
+          <p className="text-sm text-amber-700 font-medium">Gold AI is thinking... showing top 3 candidate moves.</p>
+        )}
 
         {started && !state.gameOver && (
           <button
@@ -352,7 +428,8 @@ export default function BlackHolePage() {
                 {row.map((cell) => {
                   const isSelected = state.selected?.id === cell.id;
                   const isHovered = state.hovered?.id === cell.id;
-                  const previewActive = !cell.move && (isSelected || (!state.selected && isHovered));
+                  const aiCandidateRank = state.aiCandidateIds.indexOf(cell.id);
+                  const previewActive = !cell.move && (isSelected || (!state.selected && isHovered) || aiCandidateRank >= 0);
                   const previewColor = currentPlayer ? COLOR_STYLES[currentPlayer.key] : null;
                   const showBlackHolePreview = blackHolePreview?.id === cell.id;
                   const isBlackHole = state.blackHole?.id === cell.id;
@@ -379,6 +456,11 @@ export default function BlackHolePage() {
                   if (previewActive && previewColor) {
                     circleClass += ` ring-2 ${previewColor.ring} border-transparent`;
                     numberClass = `relative z-10 ${previewColor.number} opacity-30`;
+                    shownNumber = state.nextValues[currentPlayer.key];
+                  }
+
+                  if (aiCandidateRank >= 0) {
+                    circleClass += ' ring-4 ring-amber-300';
                     shownNumber = state.nextValues[currentPlayer.key];
                   }
 

--- a/src/app/hex/page.js
+++ b/src/app/hex/page.js
@@ -19,21 +19,26 @@ function getNeighbors(row, col, size) {
   ].filter(([r, c]) => r >= 0 && r < size && c >= 0 && c < size);
 }
 
-function playerHasConnection(board, player) {
+function findWinningPath(board, player) {
   const size = board.length;
   const stack = [];
   const visited = new Set();
+  const parent = new Map();
 
   if (player === 'Blue') {
     for (let col = 0; col < size; col += 1) {
       if (board[0][col] === player) {
+        const key = `0:${col}`;
         stack.push([0, col]);
+        parent.set(key, null);
       }
     }
   } else {
     for (let row = 0; row < size; row += 1) {
       if (board[row][0] === player) {
+        const key = `${row}:0`;
         stack.push([row, 0]);
+        parent.set(key, null);
       }
     }
   }
@@ -45,22 +50,26 @@ function playerHasConnection(board, player) {
     if (visited.has(key)) continue;
     visited.add(key);
 
-    if (player === 'Blue' && row === size - 1) {
-      return true;
-    }
-
-    if (player === 'Red' && col === size - 1) {
-      return true;
+    if ((player === 'Blue' && row === size - 1) || (player === 'Red' && col === size - 1)) {
+      const path = new Set();
+      let current = key;
+      while (current) {
+        path.add(current);
+        current = parent.get(current);
+      }
+      return path;
     }
 
     getNeighbors(row, col, size).forEach(([nextRow, nextCol]) => {
-      if (board[nextRow][nextCol] === player) {
-        stack.push([nextRow, nextCol]);
-      }
+      if (board[nextRow][nextCol] !== player) return;
+      const nextKey = `${nextRow}:${nextCol}`;
+      if (visited.has(nextKey) || parent.has(nextKey)) return;
+      parent.set(nextKey, key);
+      stack.push([nextRow, nextCol]);
     });
   }
 
-  return false;
+  return null;
 }
 
 function buildInitialGame() {
@@ -68,6 +77,7 @@ function buildInitialGame() {
     board: createBoard(BOARD_SIZE),
     currentPlayer: 'Blue',
     winner: null,
+    winningPath: new Set(),
     moves: 0,
   };
 }
@@ -96,11 +106,13 @@ export default function HexPage() {
       const board = prev.board.map((line) => [...line]);
       board[row][col] = prev.currentPlayer;
 
-      const winner = playerHasConnection(board, prev.currentPlayer) ? prev.currentPlayer : null;
+      const winningPath = findWinningPath(board, prev.currentPlayer);
+      const winner = winningPath ? prev.currentPlayer : null;
 
       return {
         board,
         winner,
+        winningPath: winningPath ?? new Set(),
         currentPlayer: winner ? prev.currentPlayer : prev.currentPlayer === 'Blue' ? 'Red' : 'Blue',
         moves: prev.moves + 1,
       };
@@ -158,6 +170,7 @@ export default function HexPage() {
                 const isBottom = rowIndex === BOARD_SIZE - 1;
                 const isLeft = colIndex === 0;
                 const isRight = colIndex === BOARD_SIZE - 1;
+                const isWinningCell = game.winningPath.has(`${rowIndex}:${colIndex}`);
 
                 const borderStyle = {
                   borderTopColor: isTop ? '#2563EB' : undefined,
@@ -176,13 +189,13 @@ export default function HexPage() {
                     type="button"
                     onClick={() => handleMove(rowIndex, colIndex)}
                     disabled={Boolean(cell) || Boolean(game.winner)}
-                    className={`hex-cell border border-slate-400 mx-[2px] transition-colors ${
+                    className={`hex-cell border border-slate-400 mx-[2px] transition-all ${
                       isBlue
                         ? 'bg-blue-500 border-blue-600'
                         : isRed
                         ? 'bg-rose-500 border-rose-600'
                         : 'bg-slate-100 hover:bg-slate-200'
-                    } ${game.winner ? 'cursor-default' : ''}`}
+                    } ${isWinningCell ? 'ring-4 ring-amber-300 shadow-[0_0_12px_rgba(251,191,36,0.8)]' : ''} ${game.winner ? 'cursor-default' : ''}`}
                     style={borderStyle}
                     aria-label={`Row ${rowIndex + 1}, column ${colIndex + 1}`}
                   />

--- a/src/app/slitherlink/page.js
+++ b/src/app/slitherlink/page.js
@@ -239,8 +239,8 @@ export default function SlitherlinkPage() {
       </div>
       <h1 className="text-3xl font-bold text-center">Slitherlink Demo</h1>
 
-      <section className="w-full max-w-5xl rounded-xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
-        <h2 className="text-2xl font-semibold mb-3">How to play</h2>
+      <section className="w-full max-w-5xl rounded-xl border border-blue-200 bg-[#eef6ff] p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">How to Play</h2>
         <ul className="list-disc pl-5 space-y-2 text-slate-700">
           <li>Click line segments to draw your loop.</li>
           <li>Each clue says exactly how many sides of that cell are in the loop.</li>


### PR DESCRIPTION
### Motivation
- Make Slitherlink match the shared Demo Package instruction styling for visual consistency across projects. 
- Improve Hex UX by clearly indicating the actual winning connection when a game ends. 
- Provide a simple AI opponent option for Black Hole so users can play a 2-player game against an automated Gold player that previews its choices.

### Description
- Slitherlink: updated the instruction panel to the same blue-tinted DP “How to Play” card and adjusted the heading capitalization in `src/app/slitherlink/page.js`.
- Hex: added `findWinningPath` to detect the winning connection, stored the path on win as `winningPath`, and visually highlighted winning cells with an amber ring and glow in `src/app/hex/page.js`.
- Black Hole: introduced Gold as a second-player color and an optional AI mode in `src/app/black-hole/page.js`, added AI state (`aiCandidateIds`, `aiThinking`, `aiEnabled`) and a UI checkbox to enable `Play vs AI (Gold)`, prevented manual clicks while the AI controls Gold, and implemented an AI `useEffect` that scores open cells, shows the top three candidate previews, waits 1.5s, then commits the chosen move and advances the turn.
- Small support changes: imported `useRef` where needed and reset AI timers on cleanup to avoid leaks.

### Testing
- Ran `next lint --file src/app/black-hole/page.js --file src/app/hex/page.js --file src/app/slitherlink/page.js` and the linter completed with no errors.
- Attempted to capture UI screenshots via `npx playwright screenshot` but browser installation failed in this environment due to a CDN/domain restriction (Playwright download returned `403 Domain forbidden`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61d55d2388321aa34334667d8a208)