### PR TITLE
Slitherlink: add reveal; fix Black Hole player colors and Hex win detection

### DIFF
--- a/src/app/black-hole/page.js
+++ b/src/app/black-hole/page.js
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 const PLAYER_CONFIGS = {
   2: [
     { key: 'red', label: 'Red' },
-    { key: 'gold', label: 'Gold' },
+    { key: 'blue', label: 'Blue' },
   ],
   3: [
     { key: 'red', label: 'Red' },
@@ -21,6 +21,13 @@ const COLOR_STYLES = {
     fill: 'bg-red-100',
     winnerRing: 'ring-red-500/95',
     winnerGlow: 'shadow-[0_0_26px_rgba(239,68,68,0.75)]',
+  },
+  blue: {
+    ring: 'ring-blue-500',
+    number: 'text-blue-700',
+    fill: 'bg-blue-100',
+    winnerRing: 'ring-blue-500/95',
+    winnerGlow: 'shadow-[0_0_26px_rgba(59,130,246,0.75)]',
   },
   gold: {
     ring: 'ring-amber-500',
@@ -63,7 +70,9 @@ function getNeighbors(row, col, height) {
 }
 
 function initialState(playerCount, aiEnabled = false) {
-  const players = PLAYER_CONFIGS[playerCount];
+  const players = playerCount === 2 && aiEnabled
+    ? [{ key: 'red', label: 'Red' }, { key: 'gold', label: 'Gold (AI)' }]
+    : PLAYER_CONFIGS[playerCount];
   const height = playerCount === 2 ? 6 : 7;
   const nextValues = Object.fromEntries(players.map((player) => [player.key, 1]));
 

--- a/src/app/hex/page.js
+++ b/src/app/hex/page.js
@@ -10,12 +10,12 @@ function createBoard(size) {
 
 function getNeighbors(row, col, size) {
   return [
+    [row - 1, col - 1],
     [row - 1, col],
-    [row - 1, col + 1],
     [row, col - 1],
     [row, col + 1],
-    [row + 1, col - 1],
     [row + 1, col],
+    [row + 1, col + 1],
   ].filter(([r, c]) => r >= 0 && r < size && c >= 0 && c < size);
 }
 

--- a/src/app/slitherlink/page.js
+++ b/src/app/slitherlink/page.js
@@ -146,6 +146,8 @@ function createPuzzleState(hintDensityPercent) {
   return {
     clues: createPuzzleFromSolution(solution, hintDensityPercent),
     edges: createEmptyEdges(),
+    solutionEdges: solution,
+    revealSolution: false,
   };
 }
 
@@ -232,6 +234,10 @@ export default function SlitherlinkPage() {
     setState(createPuzzleState(hintDensity));
   }
 
+  function toggleRevealSolution() {
+    setState((prev) => ({ ...prev, revealSolution: !prev.revealSolution }));
+  }
+
   return (
     <main className="min-h-screen p-6 md:p-8 flex flex-col items-center gap-5">
       <div className="w-full max-w-5xl flex items-center justify-between">
@@ -264,7 +270,12 @@ export default function SlitherlinkPage() {
             className="w-full"
           />
           <p className="text-sm text-slate-600">Lower density gives fewer clues and a harder puzzle. Puzzle numbers are still generator-driven.</p>
-          <button type="button" className="px-4 py-2 rounded bg-slate-900 text-white hover:bg-slate-700" onClick={newPuzzle}>New Puzzle</button>
+          <div className="flex gap-3">
+            <button type="button" className="px-4 py-2 rounded bg-slate-900 text-white hover:bg-slate-700" onClick={newPuzzle}>New Puzzle</button>
+            <button type="button" className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-500" onClick={toggleRevealSolution}>
+              {state.revealSolution ? 'Hide Solution' : 'Reveal Solution'}
+            </button>
+          </div>
         </div>
       </section>
 
@@ -272,13 +283,13 @@ export default function SlitherlinkPage() {
         <div className="relative" style={{ width: SIZE * 44 + 1, height: SIZE * 44 + 1 }}>
           {Array.from({ length: SIZE + 1 }).map((_, row) =>
             Array.from({ length: SIZE }).map((__, col) => (
-              <button key={`h-${row}-${col}`} type="button" onClick={() => toggleHorizontal(row, col)} className={`absolute h-2 rounded-full ${state.edges.horizontal[row][col] ? 'bg-sky-600' : 'bg-slate-200 hover:bg-slate-400'}`} style={{ top: row * 44 - 4, left: col * 44 + 4, width: 36 }} />
+              <button key={`h-${row}-${col}`} type="button" onClick={() => toggleHorizontal(row, col)} className={`absolute h-2 rounded-full ${state.edges.horizontal[row][col] ? 'bg-sky-600' : state.revealSolution && state.solutionEdges.horizontal[row][col] ? 'bg-emerald-400/80' : 'bg-slate-200 hover:bg-slate-400'}`} style={{ top: row * 44 - 4, left: col * 44 + 4, width: 36 }} />
             ))
           )}
 
           {Array.from({ length: SIZE }).map((_, row) =>
             Array.from({ length: SIZE + 1 }).map((__, col) => (
-              <button key={`v-${row}-${col}`} type="button" onClick={() => toggleVertical(row, col)} className={`absolute w-2 rounded-full ${state.edges.vertical[row][col] ? 'bg-sky-600' : 'bg-slate-200 hover:bg-slate-400'}`} style={{ top: row * 44 + 4, left: col * 44 - 4, height: 36 }} />
+              <button key={`v-${row}-${col}`} type="button" onClick={() => toggleVertical(row, col)} className={`absolute w-2 rounded-full ${state.edges.vertical[row][col] ? 'bg-sky-600' : state.revealSolution && state.solutionEdges.vertical[row][col] ? 'bg-emerald-400/80' : 'bg-slate-200 hover:bg-slate-400'}`} style={{ top: row * 44 + 4, left: col * 44 - 4, height: 36 }} />
             ))
           )}
 


### PR DESCRIPTION
### Motivation
- Slitherlink needed a way to show the generated solution after puzzle generation without overwriting player input.  
- Black Hole 2-player behavior should use Red vs Blue in normal play and keep Gold for AI games, and 3-player rendering was crashing due to a missing color mapping.  
- Hex victory highlighting was unreliable because neighbor topology used for pathfinding didn’t match the board geometry.

### Description
- Added solution persistence and a reveal toggle to Slitherlink by storing `solutionEdges` and `revealSolution` in the puzzle state and adding a `Reveal Solution` / `Hide Solution` control that overlays generated edges (green) while preserving user-drawn lines (`src/app/slitherlink/page.js`).  
- Updated Black Hole player setup to use classic Red/Blue for 2-player non-AI and keep Gold for AI mode by deriving `players` in `initialState`, and added the missing `blue` entry to `COLOR_STYLES` so Blue-owned cells render correctly (`src/app/black-hole/page.js`).  
- Fixed Hex neighbor topology by adjusting `getNeighbors` to match the rendered hex offset layout so `findWinningPath` returns the correct winning path and cells are highlighted on victory (`src/app/hex/page.js`).

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors.  
- Attempted automated visual validation with Playwright (`npx playwright screenshot`) for `/slitherlink`, `/black-hole`, and `/hex`, but browser download/install failed due to an external CDN 403, so screenshots could not be captured in this environment.  
- No runtime errors observed in static review of changed modules after edits (manual smoke-run prevented by Playwright/browser limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61f7ecdbc8321abdcc78124b419db)