### PR TITLE
Add Slitherlink description, refine Hex winner highlight, and enable Gold AI in Black Hole

### DIFF
--- a/src/app/black-hole/page.js
+++ b/src/app/black-hole/page.js
@@ -70,14 +70,15 @@ function getNeighbors(row, col, height) {
 }
 
 function initialState(playerCount, aiEnabled = false) {
-  const players = playerCount === 2 && aiEnabled
-    ? [{ key: 'red', label: 'Red' }, { key: 'gold', label: 'Gold (AI)' }]
+  const players = aiEnabled
+    ? [{ key: 'red', label: 'Red' }, { key: 'blue', label: 'Blue' }, { key: 'gold', label: 'Gold (AI)' }]
     : PLAYER_CONFIGS[playerCount];
-  const height = playerCount === 2 ? 6 : 7;
+  const effectivePlayerCount = aiEnabled ? 3 : playerCount;
+  const height = effectivePlayerCount === 2 ? 6 : 7;
   const nextValues = Object.fromEntries(players.map((player) => [player.key, 1]));
 
   return {
-    playerCount,
+    playerCount: effectivePlayerCount,
     players,
     board: createBoard(height),
     height,
@@ -340,6 +341,7 @@ export default function BlackHolePage() {
         <h2 className="text-2xl font-semibold mb-3">How to Play</h2>
         <ul className="list-disc pl-5 space-y-2 text-slate-700">
           <li>Choose 2 players (height 6) or 3 players (height 7), then start.</li>
+          <li>Enable AI to play Red vs Blue vs Gold (AI), with Gold always moving last.</li>
           <li>On each turn, pick one open circle and confirm the move.</li>
           <li>Each player places increasing numbers: 1, 2, 3, and so on for their own turns.</li>
           <li>Placed circles lock immediately. No undo moves are allowed.</li>
@@ -363,7 +365,7 @@ export default function BlackHolePage() {
             <option value={3}>3 players</option>
           </select>
 
-          {!started && playerCount === 2 && (
+          {!started && (
             <label className="inline-flex items-center gap-2 text-sm text-slate-700">
               <input type="checkbox" checked={aiEnabled} onChange={(event) => setAiEnabled(event.target.checked)} />
               Play vs AI (Gold)

--- a/src/app/hex/page.js
+++ b/src/app/hex/page.js
@@ -4,6 +4,11 @@ import { useMemo, useState } from 'react';
 
 const BOARD_SIZE = 11;
 
+const WIN_HIGHLIGHT = {
+  Blue: 'ring-4 ring-blue-500/95 shadow-[0_0_26px_rgba(59,130,246,0.75)]',
+  Red: 'ring-4 ring-red-500/95 shadow-[0_0_26px_rgba(239,68,68,0.75)]',
+};
+
 function createBoard(size) {
   return Array.from({ length: size }, () => Array(size).fill(null));
 }
@@ -195,7 +200,7 @@ export default function HexPage() {
                         : isRed
                         ? 'bg-rose-500 border-rose-600'
                         : 'bg-slate-100 hover:bg-slate-200'
-                    } ${isWinningCell ? 'ring-4 ring-amber-300 shadow-[0_0_12px_rgba(251,191,36,0.8)]' : ''} ${game.winner ? 'cursor-default' : ''}`}
+                    } ${isWinningCell ? WIN_HIGHLIGHT[cell] : ''} ${game.winner ? 'cursor-default' : ''}`}
                     style={borderStyle}
                     aria-label={`Row ${rowIndex + 1}, column ${colIndex + 1}`}
                   />

--- a/src/app/slitherlink/page.js
+++ b/src/app/slitherlink/page.js
@@ -245,6 +245,18 @@ export default function SlitherlinkPage() {
       </div>
       <h1 className="text-3xl font-bold text-center">Slitherlink Demo</h1>
 
+      <section className="w-full max-w-5xl rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-2xl font-semibold mb-3">About the game</h2>
+        <p className="text-slate-700 mb-3">
+          Slitherlink is a logic puzzle where you draw one continuous loop around numbered cells on a square grid.
+          The numbers indicate exactly how many edges of that cell belong to the final loop.
+        </p>
+        <p className="text-slate-700">
+          The loop cannot branch, cross, or leave loose ends, so each used grid point must connect to exactly two
+          drawn edges.
+        </p>
+      </section>
+
       <section className="w-full max-w-5xl rounded-xl border border-blue-200 bg-[#eef6ff] p-5 shadow-sm">
         <h2 className="text-2xl font-semibold mb-3">How to Play</h2>
         <ul className="list-disc pl-5 space-y-2 text-slate-700">


### PR DESCRIPTION
### Motivation
- Bring Slitherlink page structure inline with other demo packages by adding a short description block before the "How to Play" section. 
- Use consistent winner-colored emphasis for Hex winning paths so the visual language matches Black Hole winner styling. 
- Enable an AI opponent in Black Hole that participates as the Gold player and always moves last while preserving the traditional player sets when AI is off. 

### Description
- Added an `About the game` panel to the Slitherlink page to match other DPs and explain the puzzle rules (`src/app/slitherlink/page.js`).
- Introduced `WIN_HIGHLIGHT` styling and applied it to Hex winning cells to replace the previous amber ring (`src/app/hex/page.js`).
- Changed Black Hole initialization so AI mode uses a 3-player lineup `[{ key: 'red' }, { key: 'blue' }, { key: 'gold' }]`, set an `effectivePlayerCount`, and store `playerCount` accordingly so Gold will be the last mover when `aiEnabled` is true (`src/app/black-hole/page.js`).
- Updated Black Hole UI and help text to expose the AI toggle consistently and document the `Red vs Blue vs Gold (AI)` mode while leaving non-AI behavior unchanged. 

### Testing
- Ran linting with `npm run lint` and it completed with no ESLint errors. 
- Launched the dev server with `npm run dev` to smoke-test the site; the process was started in the background. 
- Attempted automated page screenshots via Playwright (`npx playwright screenshot ...`) but Playwright browser binaries could not be downloaded in this environment (`npx playwright install chromium` failed with CDN 403), so UI screenshots could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74d57c1948321a0f251bb3505dd70)