### PR TITLE
Hex: use light winner-tinted backgrounds for winning path

### DIFF
--- a/src/app/hex/page.js
+++ b/src/app/hex/page.js
@@ -4,9 +4,9 @@ import { useMemo, useState } from 'react';
 
 const BOARD_SIZE = 11;
 
-const WIN_HIGHLIGHT = {
-  Blue: 'ring-4 ring-blue-500/95 shadow-[0_0_26px_rgba(59,130,246,0.75)]',
-  Red: 'ring-4 ring-red-500/95 shadow-[0_0_26px_rgba(239,68,68,0.75)]',
+const WIN_PATH_BACKGROUND = {
+  Blue: 'bg-blue-200 border-blue-300',
+  Red: 'bg-rose-200 border-rose-300',
 };
 
 function createBoard(size) {
@@ -196,11 +196,15 @@ export default function HexPage() {
                     disabled={Boolean(cell) || Boolean(game.winner)}
                     className={`hex-cell border border-slate-400 mx-[2px] transition-all ${
                       isBlue
-                        ? 'bg-blue-500 border-blue-600'
+                        ? isWinningCell
+                          ? WIN_PATH_BACKGROUND.Blue
+                          : 'bg-blue-500 border-blue-600'
                         : isRed
-                        ? 'bg-rose-500 border-rose-600'
+                        ? isWinningCell
+                          ? WIN_PATH_BACKGROUND.Red
+                          : 'bg-rose-500 border-rose-600'
                         : 'bg-slate-100 hover:bg-slate-200'
-                    } ${isWinningCell ? WIN_HIGHLIGHT[cell] : ''} ${game.winner ? 'cursor-default' : ''}`}
+                    } ${game.winner ? 'cursor-default' : ''}`}
                     style={borderStyle}
                     aria-label={`Row ${rowIndex + 1}, column ${colIndex + 1}`}
                   />


### PR DESCRIPTION
### Motivation
- The existing ring/glow highlight for the Hex winning path was not rendering consistently, so winning cells should use a subtle, accessible background tint matching the winner's color instead.

### Description
- Replaced the ring/glow highlight constant with a `WIN_PATH_BACKGROUND` mapping that defines light background and border classes for `Blue` and `Red` in `src/app/hex/page.js`.
- Updated the cell rendering logic to apply the light winner-tinted background for cells that are part of the `game.winningPath` while leaving normal stones and empty-cell hover behavior unchanged.
- Removed the previous winning-path ring/glow class usage so the visual win indicator is now a background tint.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors.
- Started the dev server with `npm run dev` to validate the change applied at runtime (server started successfully in the background).
- Attempted to capture a screenshot via `npx playwright screenshot` and to run `npx playwright install chromium`, but both Playwright browser download steps failed due to a CDN/download restriction (403), so screenshot capture could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75a1e2228832182644b2f64bf2f23)