### PR TITLE
Black Hole: fix 2-player AI roster (replace Blue with Gold)

### DIFF
--- a/src/app/black-hole/page.js
+++ b/src/app/black-hole/page.js
@@ -71,9 +71,11 @@ function getNeighbors(row, col, height) {
 
 function initialState(playerCount, aiEnabled = false) {
   const players = aiEnabled
-    ? [{ key: 'red', label: 'Red' }, { key: 'blue', label: 'Blue' }, { key: 'gold', label: 'Gold (AI)' }]
+    ? (playerCount === 2
+      ? [{ key: 'red', label: 'Red' }, { key: 'gold', label: 'Gold (AI)' }]
+      : [{ key: 'red', label: 'Red' }, { key: 'blue', label: 'Blue' }, { key: 'gold', label: 'Gold (AI)' }])
     : PLAYER_CONFIGS[playerCount];
-  const effectivePlayerCount = aiEnabled ? 3 : playerCount;
+  const effectivePlayerCount = players.length;
   const height = effectivePlayerCount === 2 ? 6 : 7;
   const nextValues = Object.fromEntries(players.map((player) => [player.key, 1]));
 
@@ -341,7 +343,7 @@ export default function BlackHolePage() {
         <h2 className="text-2xl font-semibold mb-3">How to Play</h2>
         <ul className="list-disc pl-5 space-y-2 text-slate-700">
           <li>Choose 2 players (height 6) or 3 players (height 7), then start.</li>
-          <li>Enable AI to play Red vs Blue vs Gold (AI), with Gold always moving last.</li>
+          <li>Enable AI to replace the last seat with Gold (AI), with Gold always moving last.</li>
           <li>On each turn, pick one open circle and confirm the move.</li>
           <li>Each player places increasing numbers: 1, 2, 3, and so on for their own turns.</li>
           <li>Placed circles lock immediately. No undo moves are allowed.</li>


### PR DESCRIPTION
### Motivation
- Fix a bug where enabling Play vs AI in 2-player mode kept Blue in the turn order instead of replacing the last seat with the Gold AI.

### Description
- Update `initialState` in `src/app/black-hole/page.js` to build the `players` array from `playerCount` when `aiEnabled` (2-player + AI → `[Red, Gold (AI)]`, 3-player + AI → `[Red, Blue, Gold (AI)]`) and derive `effectivePlayerCount` from `players.length`, and update the How to Play copy to reflect that AI replaces the last seat with Gold.

### Testing
- Ran `npm run -s lint -- src/app/black-hole/page.js`, which failed in this environment because Next.js lint requires a detected `app`/`pages` root and not because of the code change; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75c3a2e98832195edebbd270f3287)