### PR TITLE
Move captcha DP into Tools section and add Back button

### DIFF
--- a/src/app/captcha-dp/page.js
+++ b/src/app/captcha-dp/page.js
@@ -231,6 +231,7 @@ function drawCaptcha(canvas) {
 }
 
 export default function CaptchaDemo() {
+  const demosHref = process.env.NODE_ENV === 'production' ? '/Demos' : '/';
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -239,6 +240,16 @@ export default function CaptchaDemo() {
 
   return (
     <main className="flex min-h-screen flex-col items-center p-8 gap-6">
+      <div className="w-full max-w-3xl flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => window.location.assign(demosHref)}
+          className="px-3 py-2 rounded bg-slate-200 hover:bg-slate-300 text-slate-800"
+        >
+          ← Back
+        </button>
+      </div>
+
       <section className="w-full max-w-3xl rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-xl">
         <div className="mb-5">
           <p className="text-sm font-semibold uppercase tracking-[0.25em] text-cyan-700">Demo Package</p>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -65,12 +65,6 @@ export default function Home() {
       previewImage: '/lottery-hash-dp-preview.svg',
     },
     {
-      route: 'captcha-dp',
-      title: 'Captcha Generator Demo',
-      description: 'Generate noisy split-panel captchas from secure random passwords',
-      previewImage: '/captcha-dp-preview.svg',
-    },
-    {
       route: 'wasm-vs-js',
       title: 'WASM vs JS',
       description: 'Visualize the speed of WASM with recursive Fibonacci',
@@ -80,6 +74,12 @@ export default function Home() {
 
 
   const ckplaceTools = [
+    {
+      route: 'captcha-dp',
+      title: 'Captcha Generator Demo',
+      description: 'Generate noisy split-panel captchas from secure random passwords',
+      previewImage: '/captcha-dp-preview.svg',
+    },
     {
       route: 'ckplace-tools',
       title: 'ARC Compression Tool',


### PR DESCRIPTION
### Motivation
- Ensure the Captcha Demo Package is grouped with tools (Ckplace Tools) instead of the Demo Packages list for better categorization.
- Provide a consistent navigation experience by adding the standard `← Back` button so users can return to the demos index.

### Description
- Moved the `captcha-dp` card from the `demoPackages` array into the `ckplaceTools` array in `src/app/page.js` so it appears under the Tools section.
- Added `demosHref` and the standard `← Back` button markup to `src/app/captcha-dp/page.js` to match the navigation pattern used by other DPs.
- Fixed a small JSX syntax issue by ensuring the back button tag is properly closed in `src/app/captcha-dp/page.js`.

### Testing
- Ran `npm run lint` and received no ESLint errors (passed).
- Ran `npm run build` and the Next.js production build completed successfully (pages generated, passed).
- Captured screenshots to validate UI placement and navigation using Playwright screenshots at `screenshots/captcha-tool-section.png` and `screenshots/captcha-back-button.png` (captured successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a354f065bb88321bb6af7e78ef09260)